### PR TITLE
Isolate each static hardware-inventory probe so one failure cannot skip the rest

### DIFF
--- a/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
+++ b/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
@@ -531,6 +531,23 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
                 ];
         }
 
+        // Each static-inventory probe is independent: they populate unrelated Device Capabilities
+        // sections, so one throwing must not skip the rest. It used to — a single unreadable mount
+        // (Hardware.Info's drive enumeration surfaces DriveNotFoundException for a mount path that
+        // .NET fails to unescape from /proc/mounts) aborted the whole tier, leaving storage, network
+        // AND graphics empty for a full StaticInventoryRefreshInterval with only one warning logged.
+        void TryProbe(string description, Action probe)
+        {
+            try
+            {
+                probe();
+            }
+            catch (Exception exception)
+            {
+                CaptureFailure(exception, description);
+            }
+        }
+
         try
         {
             // FAST tier — every hardware-info poll (default 1 s). Only what genuinely changes at that
@@ -554,16 +571,16 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
                 // until the interval elapses would reintroduce exactly the spike this exists to prevent.
                 _lastStaticInventoryRefreshAt = observedAt;
 
-                _hardwareInfo.RefreshMemoryList();
-                _hardwareInfo.RefreshDriveList();
-                _hardwareInfo.RefreshMotherboardList();
-                _hardwareInfo.RefreshBIOSList();
-                _hardwareInfo.RefreshComputerSystemList();
-                _hardwareInfo.RefreshOperatingSystem();
-                _hardwareInfo.RefreshNetworkAdapterList(
+                TryProbe("refresh the memory list", _hardwareInfo.RefreshMemoryList);
+                TryProbe("refresh the drive list", _hardwareInfo.RefreshDriveList);
+                TryProbe("refresh the motherboard list", _hardwareInfo.RefreshMotherboardList);
+                TryProbe("refresh the BIOS list", _hardwareInfo.RefreshBIOSList);
+                TryProbe("refresh the computer system list", _hardwareInfo.RefreshComputerSystemList);
+                TryProbe("refresh the operating system information", _hardwareInfo.RefreshOperatingSystem);
+                TryProbe("refresh the network adapter list", () => _hardwareInfo.RefreshNetworkAdapterList(
                     includeBytesPerSec: false,
                     includeNetworkAdapterConfiguration: true,
-                    millisecondsDelayBetweenTwoMeasurements: 0);
+                    millisecondsDelayBetweenTwoMeasurements: 0));
                 // Display/GPU enumeration is skipped entirely on Linux. Hardware.Info implements BOTH the
                 // video-controller list ("xrandr -q") and the monitor list ("xrandr --props") by shelling
                 // out to xrandr, and neither can work from here under ANY desktop stack:
@@ -582,14 +599,14 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
                 // rather than supplementing it, so Hardware.Info's shell-outs never happen there.
                 if (_graphicsInventoryReader.IsAvailable)
                 {
-                    _graphicsInventory = _graphicsInventoryReader.Read();
+                    TryProbe("read the graphics inventory", () => _graphicsInventory = _graphicsInventoryReader.Read());
                 }
                 else if (!OperatingSystem.IsLinux())
                 {
-                    _hardwareInfo.RefreshVideoControllerList(refreshMonitorList: true);
+                    TryProbe("refresh the video controller list", () => _hardwareInfo.RefreshVideoControllerList(refreshMonitorList: true));
                 }
 
-                RefreshComputeAccelerators();
+                TryProbe("refresh the compute accelerators", RefreshComputeAccelerators);
             }
         }
         catch (Exception exception)


### PR DESCRIPTION
Closes #64.

## Why

`ReadHardwareInfoSnapshot` refreshes nine pieces of static inventory in sequence inside one `try` block with a single `catch`. The first probe that throws skips every probe after it.

Combined with `_lastStaticInventoryRefreshAt` being stamped before the probes run — which is correct on its own terms — one failure suppresses the remaining sections for a full ten-minute interval, with one warning logged and nothing in the UI to say why.

On my machine `RefreshDriveList` threw `DriveNotFoundException` on a mount path containing a space, and the result was that **Storage, Network and Graphics were all empty**. Three unrelated sections disabled by one unreadable cloud-storage mount.

## What this changes

Each probe gets its own `try`/`catch` through a local `TryProbe` helper, so a failing probe costs only its own section and each failure is logged with the operation that produced it.

Deliberately no behaviour change beyond that: the tier still runs on the same schedule, still stamps the timestamp up front, and still logs through the existing `CaptureFailure`.

## Note on scope

This is worth having regardless of what any individual probe does wrong. The two probe-level bugs I hit are filed and fixed separately (#65, #66) — but until this is in, any future probe failure will keep hiding its own cause behind three unrelated empty pages.

Two other PRs build on this one. They will show this commit in their diffs until it merges.

## Verification

- `dotnet test` — 296 passed, 0 failed
- Both target frameworks build with zero warnings and zero errors
- Verified on real hardware: Framework 13, 13th Gen Intel, openSUSE Tumbleweed

---
Written with AI assistance; I have reviewed the change and stand behind it, per the AI Usage Notice in CONTRIBUTING.md.