### PR TITLE
Read the graphics driver version from the DRM VERSION ioctl

### DIFF
--- a/SubZeroFramework.Core/Services/Linux/DrmModeReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/DrmModeReader.cs
@@ -42,6 +42,7 @@ public static partial class DrmModeReader
     // ioctl request numbers, _IOWR('d', nr, struct). Encoding: (dir<<30)|(size<<16)|(type<<8)|nr, with
     // dir=3 for read/write and type='d'=0x64. The sizes below are the UAPI struct sizes asserted in the
     // static constructor, so a layout mistake fails loudly at startup instead of corrupting memory.
+    private const uint DrmIoctlVersion = 0xC0406400;
     private const uint DrmIoctlModeGetResources = 0xC04064A0;
     private const uint DrmIoctlModeGetCrtc = 0xC06864A1;
     private const uint DrmIoctlModeGetEncoder = 0xC01464A6;
@@ -59,6 +60,7 @@ public static partial class DrmModeReader
     {
         // The ioctl number encodes sizeof(struct); if these ever disagree the kernel would reject the call
         // (or worse, read the wrong length), so assert the agreement once rather than debug it in the field.
+        Verify<DrmVersion>(DrmIoctlVersion);
         Verify<DrmModeCardRes>(DrmIoctlModeGetResources);
         Verify<DrmModeCrtc>(DrmIoctlModeGetCrtc);
         Verify<DrmModeGetEncoder>(DrmIoctlModeGetEncoder);
@@ -295,6 +297,70 @@ public static partial class DrmModeReader
         return $"{typeName}-{connectorTypeId}";
     }
 
+    /// <summary>
+    /// The driver's own version triple for one card, e.g. "1.6.0" for i915 — or null if unavailable.
+    /// </summary>
+    /// <remarks>
+    /// This exists because <c>/sys/module/&lt;driver&gt;/version</c> only exists for out-of-tree modules (NVIDIA's
+    /// DKMS build has one; i915, amdgpu and nouveau built in-tree do not), so the sysfs path reports nothing on
+    /// most machines. The DRM VERSION ioctl answers for every driver.
+    ///
+    /// Only the version triple is read. The struct also carries name/date/desc strings, but they need a second
+    /// call with caller-allocated buffers, and the one field worth having — <c>date</c> — is dead: upstream
+    /// removed DRIVER_DATE, and current kernels return the literal string "0". The triple comes back on the
+    /// first call with null string pointers, so this needs no buffer management at all.
+    ///
+    /// Read-only and takes no DRM master, exactly like the mode queries above.
+    /// </remarks>
+    public static string? ReadDriverVersion(int cardIndex, ILogger? logger = null, string deviceRoot = "/dev/dri")
+    {
+        var devicePath = Path.Combine(deviceRoot, $"card{cardIndex}");
+        if (!File.Exists(devicePath))
+        {
+            return null;
+        }
+
+        var fd = -1;
+        try
+        {
+            fd = Open(devicePath, OpenReadOnly | OpenCloseOnExec);
+            if (fd < 0)
+            {
+                return null;
+            }
+
+            unsafe
+            {
+                var version = default(DrmVersion);
+                if (Ioctl(fd, DrmIoctlVersion, &version) != 0)
+                {
+                    return null;
+                }
+
+                // A driver that reports 0.0.0 is telling us nothing; surface null so the UI says Unknown
+                // rather than printing a meaningless triple.
+                if (version.VersionMajor == 0 && version.VersionMinor == 0 && version.VersionPatchLevel == 0)
+                {
+                    return null;
+                }
+
+                return $"{version.VersionMajor}.{version.VersionMinor}.{version.VersionPatchLevel}";
+            }
+        }
+        catch (Exception exception) when (exception is DllNotFoundException or EntryPointNotFoundException or IOException or UnauthorizedAccessException)
+        {
+            logger?.LogDebug(exception, "Could not read the DRM driver version for card {CardIndex}.", cardIndex);
+            return null;
+        }
+        finally
+        {
+            if (fd >= 0)
+            {
+                _ = Close(fd);
+            }
+        }
+    }
+
     [LibraryImport("libc", EntryPoint = "open", StringMarshalling = StringMarshalling.Utf8, SetLastError = true)]
     private static partial int Open(string path, int flags);
 
@@ -369,6 +435,25 @@ public static partial class DrmModeReader
         public uint CrtcId;
         public uint PossibleCrtcs;
         public uint PossibleClones;
+    }
+
+    /// <summary>
+    /// UAPI <c>struct drm_version</c>. The three ints are followed by 4 bytes of padding before the first
+    /// pointer-sized field on a 64-bit ABI; the static constructor asserts the resulting 64-byte size against
+    /// the size encoded in the ioctl number, so a layout mistake fails at startup rather than in the kernel.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    private struct DrmVersion
+    {
+        public int VersionMajor;
+        public int VersionMinor;
+        public int VersionPatchLevel;
+        public nuint NameLen;
+        public ulong NamePtr;
+        public nuint DateLen;
+        public ulong DatePtr;
+        public nuint DescLen;
+        public ulong DescPtr;
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/SubZeroFramework.Core/Services/Linux/LinuxDrmGraphicsInventoryReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/LinuxDrmGraphicsInventoryReader.cs
@@ -261,17 +261,31 @@ public sealed class LinuxDrmGraphicsInventoryReader(
         return 0;
     }
 
-    /// <summary>Kernel module version, e.g. /sys/module/amdgpu/version. Absent for in-tree modules built-in.</summary>
-    private static string? ReadDriverVersion(CardRecord card)
+    /// <summary>
+    /// Kernel module version, e.g. /sys/module/nvidia/version, falling back to the driver's own DRM version.
+    /// </summary>
+    /// <remarks>
+    /// The module attribute only exists for out-of-tree modules, so on a machine running any in-tree driver
+    /// (i915, amdgpu, nouveau — i.e. most machines) it is absent and this used to report nothing. The DRM
+    /// VERSION ioctl answers for every driver, so it backs the sysfs path rather than replacing it: where a
+    /// module version exists it is the more specific answer (NVIDIA's "580.82.09" beats its DRM triple).
+    /// </remarks>
+    private string? ReadDriverVersion(CardRecord card)
     {
-        if (string.IsNullOrWhiteSpace(card.Driver))
+        if (!string.IsNullOrWhiteSpace(card.Driver))
         {
-            return null;
+            // The module version path is outside the DRM tree, so it is derived from the sysfs root of the card.
+            var moduleVersion = DrmSysfs.ReadAttribute(Path.Combine("/sys", "module", card.Driver, "version"));
+            if (!string.IsNullOrWhiteSpace(moduleVersion))
+            {
+                return moduleVersion;
+            }
         }
 
-        // The module version path is outside the DRM tree, so it is derived from the sysfs root of the card.
-        var moduleVersion = DrmSysfs.ReadAttribute(Path.Combine("/sys", "module", card.Driver, "version"));
-        return string.IsNullOrWhiteSpace(moduleVersion) ? null : moduleVersion;
+        // "card0" -> 0; the DRM device node index matches the sysfs card index.
+        return int.TryParse(card.CardName.AsSpan(4), out var cardIndex)
+            ? DrmModeReader.ReadDriverVersion(cardIndex, logger)
+            : null;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #67.

## Why

`ReadDriverVersion` reads `/sys/module/<driver>/version`, an attribute that only exists for out-of-tree modules. It works for NVIDIA's DKMS build and finds nothing for `i915`, `amdgpu` or `nouveau` — so the Driver version field is empty on most Linux machines.

On this machine:

```
$ ls /sys/module/i915/version
ls: cannot access '/sys/module/i915/version': No such file or directory
```

while the DRM `VERSION` ioctl answers immediately:

```
/dev/dri/card1: version=1.6.0 name='i915' date='0' desc='Intel Graphics'
```

## What this changes

Adds `DrmModeReader.ReadDriverVersion`, used as a fallback when the module attribute is absent. `DrmModeReader` already performs four read-only DRM ioctls, so this is the same technique in the same file, verified the same way — the struct size is asserted against the size encoded in the ioctl number in the static constructor.

The ioctl backs the sysfs path rather than replacing it. Where a module version exists it is the more specific answer, so NVIDIA keeps reporting `580.82.09` rather than a DRM interface triple.

Only the version triple is read. The struct also carries name, date and description strings, but those need a second call with caller-allocated buffers, and the field that would be worth having is dead: upstream removed `DRIVER_DATE` and current kernels return the literal string `"0"`, as the probe above shows. The triple comes back on the first call with null string pointers, so there is no buffer management. `DriverDate: null` is unchanged and remains correct.

Read-only and takes no DRM master, like the existing mode queries, so it is safe alongside a running compositor.

## What this does not fix

Two other fields on the same card stay Unknown, and I do not believe either can be fixed:

- **Driver date** — dead upstream, as above.
- **Adapter RAM** — `ReadVideoMemoryBytes` looks for amdgpu-specific attributes. An integrated GPU exposes no memory attributes and has no dedicated VRAM, so Unknown is the honest answer; reporting shared system memory would be misleading. This should already populate on a discrete card, though I have no discrete Framework GPU module to confirm that on.

## Verification

- `dotnet test` — 296 passed, 0 failed
- Both target frameworks build with zero warnings and zero errors
- Verified on real hardware: Framework 13, 13th Gen Intel, Raptor Lake-P integrated graphics — reports `1.6.0` where the field was previously empty

I could not test the NVIDIA path or a discrete GPU; I have neither. The sysfs branch is unchanged for those, so the risk is that the fallback is never reached rather than that it returns something wrong.

---
Written with AI assistance; I have reviewed the change and stand behind it, per the AI Usage Notice in CONTRIBUTING.md.