### PR TITLE
Enumerate physical drives from /sys/block on Linux

### DIFF
--- a/SubZeroFramework.Core/Models/DriveInventory.cs
+++ b/SubZeroFramework.Core/Models/DriveInventory.cs
@@ -1,0 +1,40 @@
+namespace SubZeroFramework.Models;
+
+/// <summary>
+/// Physical drives discovered outside Hardware.Info.
+/// </summary>
+/// <remarks>
+/// Exists because Hardware.Info's Linux drive enumeration never describes the physical device: it builds a
+/// single synthetic entry from mount points, leaving model, serial, firmware and size blank (verified against
+/// Hardware.Info.Aot 110.0.0.1, as root — privileges make no difference). A platform that can enumerate the
+/// real devices supplies them through <see cref="IDriveInventoryReader"/> instead, exactly as
+/// <see cref="IGraphicsInventoryReader"/> does for adapters and displays.
+/// </remarks>
+public sealed record DriveInventory
+{
+    public static DriveInventory Empty { get; } = new()
+    {
+        Drives = [],
+    };
+
+    public required IReadOnlyList<HardwareInfoDrive> Drives { get; init; }
+
+    public bool IsEmpty => Drives.Count == 0;
+}
+
+/// <summary>
+/// Supplies physical drives on platforms where Hardware.Info cannot.
+/// </summary>
+/// <remarks>
+/// Like the graphics and compute readers, every implementation is allowed to report nothing: a machine whose
+/// kernel exposes no block devices (a container with no disks of its own) must yield an empty inventory rather
+/// than throw. Runs on the SLOW inventory tier — the device set is near-static.
+/// </remarks>
+public interface IDriveInventoryReader
+{
+    /// <summary>False when this platform cannot enumerate; <see cref="Read"/> then returns empty.</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Every physical drive the platform can describe.</summary>
+    DriveInventory Read();
+}

--- a/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
+++ b/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
@@ -66,6 +66,8 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
     // sysfs and may parse the pci.ids database — far too much work for the one-second snapshot build.
     private readonly IGraphicsInventoryReader _graphicsInventoryReader;
     private GraphicsInventory _graphicsInventory = GraphicsInventory.Empty;
+    private readonly IDriveInventoryReader _driveInventoryReader;
+    private DriveInventory _driveInventory = DriveInventory.Empty;
 
     // Compute-accelerator identity (the NPU's model, driver and firmware). Static, so it is resolved on the
     // slow inventory tier and cached here — the Windows resolver alone costs hundreds of milliseconds.
@@ -133,7 +135,8 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
         IHardwareInfoLogNoiseBuffer? hardwareInfoNoiseBuffer = null,
         IComputeUtilizationReader? computeUtilizationReader = null,
         IGraphicsInventoryReader? graphicsInventoryReader = null,
-        IComputeDeviceIdentityResolver? computeDeviceIdentityResolver = null)
+        IComputeDeviceIdentityResolver? computeDeviceIdentityResolver = null,
+        IDriveInventoryReader? driveInventoryReader = null)
     {
         _frameworkSystem = frameworkSystem;
         _hardwareInfo = hardwareInfo;
@@ -149,6 +152,9 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
         // The same resolver the Windows utilization reader uses for LUID mapping also describes the devices,
         // so the NPU can be listed with a driver and firmware version rather than just a name and a percentage.
         _computeDeviceIdentityResolver = computeDeviceIdentityResolver ?? UnavailableComputeDeviceIdentityResolver.Instance;
+        // Same contract for drives: a platform whose drive enumeration comes from Hardware.Info supplies no
+        // reader here and nothing changes.
+        _driveInventoryReader = driveInventoryReader ?? UnavailableDriveInventoryReader.Instance;
         SystemStatus = _systemStatus;
         FlashSnapshots = _flashSnapshots;
         FanCapabilitiesSnapshots = _fanCapabilitiesSnapshots;
@@ -572,7 +578,17 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
                 _lastStaticInventoryRefreshAt = observedAt;
 
                 TryProbe("refresh the memory list", _hardwareInfo.RefreshMemoryList);
-                TryProbe("refresh the drive list", _hardwareInfo.RefreshDriveList);
+                // Same substitution the graphics reader makes below, and for the same reason: where a platform
+                // reader exists it REPLACES Hardware.Info's enumeration rather than supplementing it, so the
+                // broken shell-out never runs. On Linux that also avoids the lshw probe entirely.
+                if (_driveInventoryReader.IsAvailable)
+                {
+                    TryProbe("read the drive inventory", () => _driveInventory = _driveInventoryReader.Read());
+                }
+                else
+                {
+                    TryProbe("refresh the drive list", _hardwareInfo.RefreshDriveList);
+                }
                 TryProbe("refresh the motherboard list", _hardwareInfo.RefreshMotherboardList);
                 TryProbe("refresh the BIOS list", _hardwareInfo.RefreshBIOSList);
                 TryProbe("refresh the computer system list", _hardwareInfo.RefreshComputerSystemList);
@@ -889,7 +905,11 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
 
         try
         {
-            if (_hardwareInfo.DriveList.Count > 0)
+            if (_driveInventoryReader.IsAvailable)
+            {
+                drives = [.. _driveInventory.Drives];
+            }
+            else if (_hardwareInfo.DriveList.Count > 0)
             {
                 drives = _hardwareInfo.DriveList
                     .Select(drive => new HardwareInfoDrive(

--- a/SubZeroFramework.Core/Services/Linux/LinuxBlockDriveInventoryReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/LinuxBlockDriveInventoryReader.cs
@@ -1,0 +1,363 @@
+using System.Globalization;
+
+using Microsoft.Extensions.Logging;
+
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Linux;
+
+/// <summary>
+/// Enumerates physical drives from the kernel's block tree, without Hardware.Info and without lshw.
+/// </summary>
+/// <remarks>
+/// This is the Linux answer to Hardware.Info's drive list, which cannot describe a real device here: its
+/// Linux implementation returns one synthetic entry built from mount points, with model, serial, firmware and
+/// size all blank. Verified against Hardware.Info.Aot 110.0.0.1 running as root — this is a library gap, not a
+/// privilege problem, so no amount of elevation fixes it.
+///
+/// Everything the UI needs is plain text under <c>/sys/block</c> and is world-readable, so this reader needs no
+/// privileges at all: <c>device/model</c>, <c>device/serial</c>, <c>device/firmware_rev</c>,
+/// <c>queue/rotational</c>, and <c>size</c> (always in 512-byte units regardless of the device's logical block
+/// size).
+///
+/// Free space is the one thing sysfs cannot answer, so it is attributed from the mount table: each mounted
+/// filesystem is traced back to the disk that ultimately backs it, through partitions AND through device-mapper
+/// slaves, so an encrypted root (LUKS: filesystem on <c>/dev/mapper/x</c> → <c>dm-N</c> → partition → disk)
+/// still reports its space against the physical drive rather than vanishing.
+///
+/// The mount table is parsed here rather than through <see cref="DriveInfo.GetDrives"/> because .NET does not
+/// decode the octal escapes the kernel writes into <c>/proc/mounts</c> for space, tab, newline and backslash —
+/// a mount path containing any of them yields a DriveInfo whose name cannot be stat'd, and asking it for
+/// DriveFormat throws. That defect is what made Hardware.Info's whole drive enumeration throw in the first
+/// place; unescaping here means a mount path with a space in it is simply handled.
+///
+/// Everything is best-effort. An unreadable attribute, a disk with no partitions, a mount whose device has
+/// disappeared, and a machine with no block devices at all each degrade the result rather than failing the
+/// inventory refresh.
+/// </remarks>
+/// <summary>
+/// Default kernel paths the drive reader enumerates. Separate from the reader so the primary constructor can
+/// use them as parameter defaults, mirroring <c>DrmSysfs</c>.
+/// </summary>
+public static class BlockSysfs
+{
+    public const string DefaultSysfsBlockRoot = "/sys/block";
+    public const string DefaultProcMountsPath = "/proc/mounts";
+}
+
+public sealed class LinuxBlockDriveInventoryReader(
+    ILogger<LinuxBlockDriveInventoryReader> logger,
+    string sysfsBlockRoot = BlockSysfs.DefaultSysfsBlockRoot,
+    string procMountsPath = BlockSysfs.DefaultProcMountsPath) : IDriveInventoryReader
+{
+    /// <summary>Kernel block size for the <c>size</c> attribute — fixed at 512 bytes, never the device's own.</summary>
+    private const ulong SysfsSectorBytes = 512;
+
+    private bool _loggedReadFailure;
+
+    /// <summary>
+    /// True when a populated block tree exists at the configured root.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT an <c>OperatingSystem.IsLinux()</c> check, for the same reason the DRM reader avoids
+    /// one: this is ordinary file I/O over an injectable root, so gating it on the OS would make the
+    /// enumeration untestable off Linux. Which platforms construct it at all is a DI decision.
+    /// </remarks>
+    public bool IsAvailable => Directory.Exists(sysfsBlockRoot);
+
+    public DriveInventory Read()
+    {
+        if (!IsAvailable)
+        {
+            return DriveInventory.Empty;
+        }
+
+        try
+        {
+            return ReadCore();
+        }
+        catch (Exception exception)
+        {
+            // The inventory tier must survive anything sysfs does; log once so a persistent problem is
+            // visible without a line per refresh.
+            if (!_loggedReadFailure)
+            {
+                _loggedReadFailure = true;
+                logger.LogWarning(exception, "Could not enumerate drives from {BlockPath}; the Storage page will be empty.", sysfsBlockRoot);
+            }
+
+            return DriveInventory.Empty;
+        }
+    }
+
+    private DriveInventory ReadCore()
+    {
+        var diskNames = Directory.EnumerateDirectories(sysfsBlockRoot)
+            .Select(Path.GetFileName)
+            .Where(name => !string.IsNullOrEmpty(name))
+            .Select(name => name!)
+            // A physical device has a "device" link; loop, ram, zram, md and device-mapper nodes do not. That
+            // single test is what keeps the Storage page showing disks rather than every virtual block device.
+            .Where(name => Directory.Exists(Path.Combine(sysfsBlockRoot, name, "device")))
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
+
+        if (diskNames.Count == 0)
+        {
+            return DriveInventory.Empty;
+        }
+
+        var freeSpaceByDisk = ReadFreeSpaceByDisk(diskNames);
+
+        List<HardwareInfoDrive> drives = [];
+        uint index = 0;
+
+        foreach (var diskName in diskNames)
+        {
+            var diskPath = Path.Combine(sysfsBlockRoot, diskName);
+            var model = ReadAttribute(diskPath, "device/model");
+            var isRotational = string.Equals(ReadAttribute(diskPath, "queue/rotational"), "1", StringComparison.Ordinal);
+            var isRemovable = string.Equals(ReadAttribute(diskPath, "removable"), "1", StringComparison.Ordinal);
+            var mediaType = isRemovable
+                ? "Removable"
+                : isRotational ? "HDD" : "SSD";
+
+            drives.Add(new HardwareInfoDrive(
+                Index: index,
+                Name: $"/dev/{diskName}",
+                Model: model,
+                Caption: model ?? $"/dev/{diskName}",
+                Description: isRotational ? "Rotational drive" : "Solid state drive",
+                // NVMe exposes no vendor attribute; SCSI/ATA do. Null rather than a guess derived from the model.
+                Manufacturer: ReadAttribute(diskPath, "device/vendor"),
+                MediaType: mediaType,
+                SerialNumber: ReadAttribute(diskPath, "device/serial"),
+                // NVMe uses firmware_rev, SCSI/ATA use rev.
+                FirmwareRevision: ReadAttribute(diskPath, "device/firmware_rev") ?? ReadAttribute(diskPath, "device/rev"),
+                Size: ReadSizeBytes(diskPath),
+                FreeSpace: freeSpaceByDisk.GetValueOrDefault(diskName)));
+
+            index++;
+        }
+
+        return new DriveInventory { Drives = drives };
+    }
+
+    private ulong ReadSizeBytes(string diskPath)
+        => ulong.TryParse(ReadAttribute(diskPath, "size"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var sectors)
+            ? sectors * SysfsSectorBytes
+            : 0;
+
+    private static string? ReadAttribute(string diskPath, string relativePath)
+    {
+        try
+        {
+            var path = Path.Combine(diskPath, relativePath);
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            // sysfs pads several of these to a fixed width (model in particular), so the raw value is unusable
+            // as a display string.
+            var value = File.ReadAllText(path).Trim();
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Sums the free space of every mounted filesystem against the physical disk that ultimately backs it.
+    /// </summary>
+    private Dictionary<string, ulong> ReadFreeSpaceByDisk(IReadOnlyCollection<string> diskNames)
+    {
+        Dictionary<string, ulong> freeSpaceByDisk = new(StringComparer.Ordinal);
+        // One filesystem can appear at several mount points (bind mounts). Counting its free space once per
+        // mount would inflate the total well past the size of the disk.
+        HashSet<string> countedDevices = new(StringComparer.Ordinal);
+
+        foreach (var (deviceName, mountPoint) in EnumerateMounts())
+        {
+            if (!countedDevices.Add(deviceName))
+            {
+                continue;
+            }
+
+            var owningDisk = ResolveOwningDisk(deviceName, diskNames);
+            if (owningDisk is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                var available = new DriveInfo(mountPoint).AvailableFreeSpace;
+                if (available > 0)
+                {
+                    freeSpaceByDisk[owningDisk] = freeSpaceByDisk.GetValueOrDefault(owningDisk) + (ulong)available;
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                // A mount can disappear between reading the table and stat'ing it, and some pseudo-filesystems
+                // refuse the call outright. Neither is a reason to lose the rest of the inventory.
+            }
+        }
+
+        return freeSpaceByDisk;
+    }
+
+    /// <summary>
+    /// Yields (kernel device name, mount point) for every real block-device mount in the table.
+    /// </summary>
+    private IEnumerable<(string DeviceName, string MountPoint)> EnumerateMounts()
+    {
+        string[] lines;
+        try
+        {
+            lines = File.ReadAllLines(procMountsPath);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            yield break;
+        }
+
+        foreach (var line in lines)
+        {
+            var fields = line.Split(' ');
+            if (fields.Length < 2)
+            {
+                continue;
+            }
+
+            var source = Unescape(fields[0]);
+            if (!source.StartsWith("/dev/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var deviceName = ResolveKernelDeviceName(source);
+            if (deviceName is null)
+            {
+                continue;
+            }
+
+            yield return (deviceName, Unescape(fields[1]));
+        }
+    }
+
+    /// <summary>
+    /// Decodes the octal escapes the kernel writes for space, tab, newline and backslash.
+    /// </summary>
+    /// <remarks>
+    /// .NET's own mount enumeration omits this step, which is why a mount path containing a space produces a
+    /// DriveInfo that throws DriveNotFoundException on any property that stats the path.
+    /// </remarks>
+    internal static string Unescape(string value)
+    {
+        if (!value.Contains('\\', StringComparison.Ordinal))
+        {
+            return value;
+        }
+
+        var builder = new System.Text.StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '\\'
+                && i + 3 < value.Length
+                && IsOctalDigit(value[i + 1])
+                && IsOctalDigit(value[i + 2])
+                && IsOctalDigit(value[i + 3]))
+            {
+                builder.Append((char)(((value[i + 1] - '0') * 64) + ((value[i + 2] - '0') * 8) + (value[i + 3] - '0')));
+                i += 3;
+                continue;
+            }
+
+            builder.Append(value[i]);
+        }
+
+        return builder.ToString();
+
+        static bool IsOctalDigit(char candidate) => candidate is >= '0' and <= '7';
+    }
+
+    /// <summary>
+    /// Turns a <c>/dev</c> path into the kernel's own device name, following symlinks so
+    /// <c>/dev/mapper/cr_root</c> resolves to <c>dm-0</c>.
+    /// </summary>
+    private static string? ResolveKernelDeviceName(string devicePath)
+    {
+        try
+        {
+            var resolved = File.ResolveLinkTarget(devicePath, returnFinalTarget: true)?.FullName ?? devicePath;
+            var name = Path.GetFileName(resolved);
+            return string.IsNullOrEmpty(name) ? null : name;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Walks from a mounted device to the physical disk backing it: a partition resolves to its parent, and a
+    /// device-mapper node resolves through its slaves (so LUKS and LVM land on the real drive).
+    /// </summary>
+    private string? ResolveOwningDisk(string deviceName, IReadOnlyCollection<string> diskNames, int depth = 0)
+    {
+        // Stacked mappers are legitimate (LVM on LUKS), but the slave graph is attacker-independent kernel
+        // state and a cycle would still hang the refresh, so the walk is bounded.
+        if (depth > 8)
+        {
+            return null;
+        }
+
+        if (diskNames.Contains(deviceName))
+        {
+            return deviceName;
+        }
+
+        // A partition lives beneath its disk: /sys/block/nvme0n1/nvme0n1p2.
+        foreach (var diskName in diskNames)
+        {
+            if (Directory.Exists(Path.Combine(sysfsBlockRoot, diskName, deviceName)))
+            {
+                return diskName;
+            }
+        }
+
+        // Device-mapper and MD nodes name their backing devices under slaves/.
+        var slavesPath = Path.Combine(sysfsBlockRoot, deviceName, "slaves");
+        if (!Directory.Exists(slavesPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            foreach (var slavePath in Directory.EnumerateFileSystemEntries(slavesPath))
+            {
+                var slaveName = Path.GetFileName(slavePath);
+                if (string.IsNullOrEmpty(slaveName))
+                {
+                    continue;
+                }
+
+                if (ResolveOwningDisk(slaveName, diskNames, depth + 1) is { } owningDisk)
+                {
+                    return owningDisk;
+                }
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/SubZeroFramework.Core/Services/Linux/UnavailableDriveInventoryReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/UnavailableDriveInventoryReader.cs
@@ -1,0 +1,20 @@
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Linux;
+
+/// <summary>
+/// Null object for platforms that get their drive inventory from Hardware.Info (Windows), so the provider
+/// never branches on null.
+/// </summary>
+public sealed class UnavailableDriveInventoryReader : IDriveInventoryReader
+{
+    public static UnavailableDriveInventoryReader Instance { get; } = new();
+
+    private UnavailableDriveInventoryReader()
+    {
+    }
+
+    public bool IsAvailable => false;
+
+    public DriveInventory Read() => DriveInventory.Empty;
+}

--- a/SubZeroFramework.Core/SubZeroFramework.Core.csproj
+++ b/SubZeroFramework.Core/SubZeroFramework.Core.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SubZeroFramework.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FrameworkDotnet" />
     <PackageReference Include="Hardware.Info.Aot" />

--- a/SubZeroFramework.Service/Program.cs
+++ b/SubZeroFramework.Service/Program.cs
@@ -112,6 +112,7 @@ public static class Program
         builder.Services.AddSingleton<IComputeDeviceIdentityResolver, WindowsComputeDeviceIdentityResolver>();
         builder.Services.AddSingleton<IComputeUtilizationReader, WindowsPdhComputeUtilizationReader>();
         builder.Services.AddSingleton<IGraphicsInventoryReader>(UnavailableGraphicsInventoryReader.Instance);
+        builder.Services.AddSingleton<IDriveInventoryReader>(UnavailableDriveInventoryReader.Instance);
 #else
         // Linux has no single counter set covering every vendor the way Windows' GPU Engine does, so each
         // source is its own reader and a composite merges them: a Framework 16 with the graphics module
@@ -133,12 +134,16 @@ public static class Program
 
             // Replaces Hardware.Info's xrandr-based enumeration, which cannot work without a display server.
             builder.Services.AddSingleton<IGraphicsInventoryReader, LinuxDrmGraphicsInventoryReader>();
+            // Replaces Hardware.Info's drive list, whose Linux implementation describes mount points rather
+            // than devices and leaves every hardware field blank.
+            builder.Services.AddSingleton<IDriveInventoryReader, LinuxBlockDriveInventoryReader>();
             builder.Services.AddSingleton<IComputeDeviceIdentityResolver, LinuxComputeDeviceIdentityResolver>();
         }
         else
         {
             builder.Services.AddSingleton<IComputeUtilizationReader>(UnavailableComputeUtilizationReader.Instance);
             builder.Services.AddSingleton<IGraphicsInventoryReader>(UnavailableGraphicsInventoryReader.Instance);
+            builder.Services.AddSingleton<IDriveInventoryReader>(UnavailableDriveInventoryReader.Instance);
             builder.Services.AddSingleton<IComputeDeviceIdentityResolver>(UnavailableComputeDeviceIdentityResolver.Instance);
         }
 #endif

--- a/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
+++ b/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
@@ -19,8 +19,15 @@ namespace SubZeroFramework.Tests;
 /// That last case is the one that started this: the kernel escapes a space as <c>\040</c> in
 /// <c>/proc/mounts</c>, .NET's own mount enumeration does not decode it, and the resulting DriveInfo throws
 /// when asked for anything that stats the path — which is what made Hardware.Info's entire drive list throw.
+///
+/// Gated to Linux despite the tree being synthetic. Free-space attribution goes through
+/// <see cref="DriveInfo"/>, whose constructor accepts a mount point on Unix but requires a drive ROOT on
+/// Windows, so the space assertions describe Unix semantics rather than the parse itself. The parsing tests
+/// alongside them would pass anywhere; they are gated with the rest rather than split, so the fixture has one
+/// platform story instead of two.
 /// </remarks>
 [TestFixture]
+[Platform("Linux")]
 public class LinuxBlockDriveInventoryReaderTests
 {
     private string _root = string.Empty;

--- a/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
+++ b/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
@@ -1,0 +1,202 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NUnit.Framework;
+
+using SubZeroFramework.Services.Linux;
+
+namespace SubZeroFramework.Tests;
+
+/// <summary>
+/// Exercises the Linux block enumeration against a synthetic sysfs tree and mount table.
+/// </summary>
+/// <remarks>
+/// The reader takes its sysfs root and mount-table path as constructor arguments precisely so this is
+/// possible: the layout of <c>/sys/block</c> is stable and documented, so a fixture tree reproduces it
+/// faithfully and covers what would otherwise need several machines — an NVMe SSD and a rotational SATA disk,
+/// a LUKS volume whose filesystem sits on a device-mapper node rather than the partition, virtual block
+/// devices that must be excluded, and a mount path containing a space.
+///
+/// That last case is the one that started this: the kernel escapes a space as <c>\040</c> in
+/// <c>/proc/mounts</c>, .NET's own mount enumeration does not decode it, and the resulting DriveInfo throws
+/// when asked for anything that stats the path — which is what made Hardware.Info's entire drive list throw.
+/// </remarks>
+[TestFixture]
+public class LinuxBlockDriveInventoryReaderTests
+{
+    private string _root = string.Empty;
+    private string _mounts = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "szf-block-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _mounts = Path.Combine(_root, "mounts");
+        File.WriteAllText(_mounts, string.Empty);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private LinuxBlockDriveInventoryReader CreateReader()
+        => new(NullLogger<LinuxBlockDriveInventoryReader>.Instance, _root, _mounts);
+
+    private void WriteAttribute(string relativePath, string value)
+    {
+        var path = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, value);
+    }
+
+    /// <summary>An NVMe SSD, padded exactly the way sysfs pads the model field.</summary>
+    private void GivenNvmeDisk(string name = "nvme0n1", string sectors = "1953525168")
+    {
+        WriteAttribute($"{name}/device/model", "CT1000P3PSSD8                           \n");
+        WriteAttribute($"{name}/device/serial", "24514CFE212E        \n");
+        WriteAttribute($"{name}/device/firmware_rev", "P9CR413 \n");
+        WriteAttribute($"{name}/queue/rotational", "0\n");
+        WriteAttribute($"{name}/removable", "0\n");
+        WriteAttribute($"{name}/size", sectors + "\n");
+    }
+
+    [Test]
+    public void Read_WhenBlockRootMissing_ReportsUnavailableAndEmpty()
+    {
+        var reader = new LinuxBlockDriveInventoryReader(
+            NullLogger<LinuxBlockDriveInventoryReader>.Instance,
+            Path.Combine(_root, "does-not-exist"),
+            _mounts);
+
+        Assert.That(reader.IsAvailable, Is.False);
+        Assert.That(reader.Read().IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Read_PopulatesHardwareFieldsFromSysfs()
+    {
+        GivenNvmeDisk();
+
+        var drive = CreateReader().Read().Drives.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(drive.Name, Is.EqualTo("/dev/nvme0n1"));
+            // sysfs pads these to a fixed width; the reader must not surface the padding.
+            Assert.That(drive.Model, Is.EqualTo("CT1000P3PSSD8"));
+            Assert.That(drive.SerialNumber, Is.EqualTo("24514CFE212E"));
+            Assert.That(drive.FirmwareRevision, Is.EqualTo("P9CR413"));
+            Assert.That(drive.MediaType, Is.EqualTo("SSD"));
+            // The size attribute is always in 512-byte units, never the device's logical block size.
+            Assert.That(drive.Size, Is.EqualTo(1953525168UL * 512UL));
+        });
+    }
+
+    [Test]
+    public void Read_WhenDiskIsRotational_ReportsHdd()
+    {
+        GivenNvmeDisk("sda");
+        WriteAttribute("sda/queue/rotational", "1\n");
+        // SCSI and ATA expose "rev" where NVMe exposes "firmware_rev".
+        File.Delete(Path.Combine(_root, "sda/device/firmware_rev"));
+        WriteAttribute("sda/device/rev", "SB10\n");
+
+        var drive = CreateReader().Read().Drives.Single();
+
+        Assert.That(drive.MediaType, Is.EqualTo("HDD"));
+        Assert.That(drive.FirmwareRevision, Is.EqualTo("SB10"));
+    }
+
+    [Test]
+    public void Read_ExcludesVirtualBlockDevices()
+    {
+        GivenNvmeDisk();
+        // loop, zram and device-mapper nodes have no "device" link — that is the whole test for exclusion.
+        Directory.CreateDirectory(Path.Combine(_root, "loop0"));
+        Directory.CreateDirectory(Path.Combine(_root, "zram0"));
+        Directory.CreateDirectory(Path.Combine(_root, "dm-0"));
+
+        var drives = CreateReader().Read().Drives;
+
+        Assert.That(drives.Select(drive => drive.Name), Is.EqualTo(new[] { "/dev/nvme0n1" }));
+    }
+
+    [Test]
+    public void Read_WhenMountPathContainsEscapedSpace_DoesNotThrow()
+    {
+        GivenNvmeDisk();
+        Directory.CreateDirectory(Path.Combine(_root, "nvme0n1", "nvme0n1p1"));
+        WriteAttribute("nvme0n1/nvme0n1p1/partition", "1\n");
+        // The kernel writes a space as \040. Decoding it is the reader's job; .NET's own enumeration omits it.
+        File.WriteAllText(_mounts, "/dev/nvme0n1p1 /mnt/Google\\040Drive ext4 rw 0 0\n");
+
+        var drives = CreateReader().Read().Drives;
+
+        Assert.That(drives, Has.Count.EqualTo(1));
+        Assert.That(drives[0].Model, Is.EqualTo("CT1000P3PSSD8"));
+    }
+
+    [TestCase("plain", "plain")]
+    [TestCase("with\\040space", "with space")]
+    [TestCase("tab\\011here", "tab\there")]
+    [TestCase("back\\134slash", "back\\slash")]
+    [TestCase("trailing\\", "trailing\\")]
+    [TestCase("\\04", "\\04")]
+    public void Unescape_DecodesOctalSequencesAndLeavesEverythingElseAlone(string input, string expected)
+        => Assert.That(LinuxBlockDriveInventoryReader.Unescape(input), Is.EqualTo(expected));
+
+    [Test]
+    public void Read_AttributesFreeSpaceThroughDeviceMapperSlaves()
+    {
+        GivenNvmeDisk();
+        Directory.CreateDirectory(Path.Combine(_root, "nvme0n1", "nvme0n1p2"));
+        WriteAttribute("nvme0n1/nvme0n1p2/partition", "2\n");
+        // A LUKS volume: the filesystem is mounted on the mapper node, which names its backing partition
+        // under slaves/. Without the walk the space would be attributed to no disk at all.
+        Directory.CreateDirectory(Path.Combine(_root, "dm-0", "slaves", "nvme0n1p2"));
+
+        // The mount point must exist for the free-space stat to succeed; the reader is expected to survive
+        // either way, so this asserts the resolution reached the disk rather than a specific byte count.
+        var mountPoint = Path.Combine(_root, "mnt");
+        Directory.CreateDirectory(mountPoint);
+        File.WriteAllText(_mounts, $"/dev/dm-0 {mountPoint.Replace(" ", "\\040")} btrfs rw 0 0\n");
+
+        var drive = CreateReader().Read().Drives.Single();
+
+        Assert.That(drive.Name, Is.EqualTo("/dev/nvme0n1"));
+        Assert.That(drive.FreeSpace, Is.GreaterThan(0UL), "free space should be traced through dm-0 to its backing disk");
+    }
+
+    [Test]
+    public void Read_CountsAFilesystemOnceAcrossManyMountPoints()
+    {
+        GivenNvmeDisk();
+        Directory.CreateDirectory(Path.Combine(_root, "nvme0n1", "nvme0n1p2"));
+        WriteAttribute("nvme0n1/nvme0n1p2/partition", "2\n");
+
+        var mountPoint = Path.Combine(_root, "mnt");
+        Directory.CreateDirectory(mountPoint);
+
+        // btrfs subvolumes surface as many mounts of ONE filesystem. Summing per mount would report multiple
+        // times the disk's real free space — on the machine this was written against, 1.18 TB on a 931 GB SSD.
+        var singleMount = $"/dev/nvme0n1p2 {mountPoint} btrfs rw 0 0\n";
+        File.WriteAllText(_mounts, singleMount);
+        var oneMountFreeSpace = CreateReader().Read().Drives.Single().FreeSpace;
+
+        File.WriteAllText(_mounts, string.Concat(Enumerable.Repeat(singleMount, 9)));
+        var nineMountFreeSpace = CreateReader().Read().Drives.Single().FreeSpace;
+
+        Assert.That(nineMountFreeSpace, Is.EqualTo(oneMountFreeSpace));
+    }
+}


### PR DESCRIPTION
Closes #65.

> **Builds on #68.** That PR's commit appears in this diff until it merges; afterwards this reduces to the drive reader alone.

## Why

`Hardware.Info`'s Linux `GetDriveList()` never looks at the physical device. It returns one synthetic entry built from mount points with every hardware field blank:

```
DriveList.Count = 1
--- Drive Index=0
  Name=[] Model=[] Caption=[] Manufacturer=[] Serial=[]
  Size=0 Firmware=[] Partitions=1
```

Identical as root, so it is a library gap rather than a privilege problem.

It also throws outright when any single mount cannot be stat'd, because it calls `DriveFormat` on every mount with no per-mount guard. .NET does not decode the octal escapes the kernel writes into `/proc/mounts`, so a path containing a space, tab, newline or backslash produces a `DriveInfo` whose path does not exist. Two ordinary configurations hit this: an rclone mount with a space in its path, and a systemd credential mount for a LUKS volume named by device ID.

## What this changes

`LinuxBlockDriveInventoryReader` reads `/sys/block`, following the pattern `IGraphicsInventoryReader` established when `xrandr` proved unusable in a headless root service. Every attribute is world-readable, so it needs no privileges and skips the `lshw` probe for drives entirely. Physical devices are told apart from loop, zram and device-mapper nodes by the presence of a `device` link.

Two details are load-bearing and both have tests:

**Free space traces through device-mapper.** An encrypted root has its filesystem on `/dev/mapper/…`, not on a partition, so the reader walks `dm-N → slaves/ → partition → disk`. Without that walk the space is attributed to no drive at all.

**A filesystem is counted once, not once per mount point.** btrfs subvolumes surface as many mounts of one filesystem — nine on my machine. Summing per mount reported 1.18 TB free on a 931 GB disk before this was fixed.

The mount table is parsed here rather than through `DriveInfo.GetDrives`, which means decoding the escapes .NET does not. That fixes the throwing case at its source instead of working around it.

## Cross-platform

Gated at registration rather than by `#if`, matching the existing Linux readers — it is ordinary file I/O over an injectable root, which is what keeps it testable off Linux. Windows registers the null object and continues to use `Hardware.Info` unchanged; the provider branches on `IsAvailable`, never on the OS. The constructor parameter is optional and defaults to the null object.

## Verification

- `dotnet test` — 309 passed, 0 failed (13 new)
- Both target frameworks build with zero warnings and zero errors
- Verified on real hardware: Framework 13, 13th Gen Intel, openSUSE Tumbleweed, encrypted btrfs root

Live output on that machine, with free space matching `df` exactly:

```
/dev/nvme0n1 — CT1000P3PSSD8
Serial 24514CFE212E · Firmware P9CR413 · SSD
931.51 GB · 110.94 GB free · 88.1% used
```

I have only one drive and one machine to test on, so the multi-disk, SATA/SCSI (`device/rev` rather than `device/firmware_rev`), removable and LVM paths are covered by tests against synthetic sysfs trees rather than by real hardware.

---
Written with AI assistance; I have reviewed the change and stand behind it, per the AI Usage Notice in CONTRIBUTING.md.