### PR TITLE
Enumerate memory modules from SMBIOS type 17 on Linux

### DIFF
--- a/SubZeroFramework.Core/Models/DriveInventory.cs
+++ b/SubZeroFramework.Core/Models/DriveInventory.cs
@@ -1,0 +1,40 @@
+namespace SubZeroFramework.Models;
+
+/// <summary>
+/// Physical drives discovered outside Hardware.Info.
+/// </summary>
+/// <remarks>
+/// Exists because Hardware.Info's Linux drive enumeration never describes the physical device: it builds a
+/// single synthetic entry from mount points, leaving model, serial, firmware and size blank (verified against
+/// Hardware.Info.Aot 110.0.0.1, as root — privileges make no difference). A platform that can enumerate the
+/// real devices supplies them through <see cref="IDriveInventoryReader"/> instead, exactly as
+/// <see cref="IGraphicsInventoryReader"/> does for adapters and displays.
+/// </remarks>
+public sealed record DriveInventory
+{
+    public static DriveInventory Empty { get; } = new()
+    {
+        Drives = [],
+    };
+
+    public required IReadOnlyList<HardwareInfoDrive> Drives { get; init; }
+
+    public bool IsEmpty => Drives.Count == 0;
+}
+
+/// <summary>
+/// Supplies physical drives on platforms where Hardware.Info cannot.
+/// </summary>
+/// <remarks>
+/// Like the graphics and compute readers, every implementation is allowed to report nothing: a machine whose
+/// kernel exposes no block devices (a container with no disks of its own) must yield an empty inventory rather
+/// than throw. Runs on the SLOW inventory tier — the device set is near-static.
+/// </remarks>
+public interface IDriveInventoryReader
+{
+    /// <summary>False when this platform cannot enumerate; <see cref="Read"/> then returns empty.</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Every physical drive the platform can describe.</summary>
+    DriveInventory Read();
+}

--- a/SubZeroFramework.Core/Models/MemoryInventory.cs
+++ b/SubZeroFramework.Core/Models/MemoryInventory.cs
@@ -1,0 +1,41 @@
+namespace SubZeroFramework.Models;
+
+/// <summary>
+/// Installed memory modules discovered outside Hardware.Info.
+/// </summary>
+/// <remarks>
+/// Exists because Hardware.Info's Linux memory list is built by parsing <c>lshw</c>, which reports the
+/// "System Memory" container node alongside the real banks — so a machine with two sticks lists three modules,
+/// the first being their total with no form factor and no speed. It also leaves manufacturer, part number,
+/// serial number, bank label, memory type and data width empty even as root. A platform that can enumerate the
+/// real devices supplies them through <see cref="IMemoryInventoryReader"/> instead, exactly as
+/// <see cref="IDriveInventoryReader"/> and <see cref="IGraphicsInventoryReader"/> do for their device classes.
+/// </remarks>
+public sealed record MemoryInventory
+{
+    public static MemoryInventory Empty { get; } = new()
+    {
+        Modules = [],
+    };
+
+    public required IReadOnlyList<HardwareInfoMemoryModule> Modules { get; init; }
+
+    public bool IsEmpty => Modules.Count == 0;
+}
+
+/// <summary>
+/// Supplies installed memory modules on platforms where Hardware.Info cannot.
+/// </summary>
+/// <remarks>
+/// Like the drive, graphics and compute readers, every implementation is allowed to report nothing: a virtual
+/// machine whose firmware publishes no memory devices must yield an empty inventory rather than throw. Runs on
+/// the SLOW inventory tier — modules do not change without a power cycle.
+/// </remarks>
+public interface IMemoryInventoryReader
+{
+    /// <summary>False when this platform cannot enumerate; <see cref="Read"/> then returns empty.</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Every installed module the platform can describe. Empty slots are omitted.</summary>
+    MemoryInventory Read();
+}

--- a/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
+++ b/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
@@ -66,6 +66,8 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
     // sysfs and may parse the pci.ids database — far too much work for the one-second snapshot build.
     private readonly IGraphicsInventoryReader _graphicsInventoryReader;
     private GraphicsInventory _graphicsInventory = GraphicsInventory.Empty;
+    private readonly IDriveInventoryReader _driveInventoryReader;
+    private DriveInventory _driveInventory = DriveInventory.Empty;
 
     // Compute-accelerator identity (the NPU's model, driver and firmware). Static, so it is resolved on the
     // slow inventory tier and cached here — the Windows resolver alone costs hundreds of milliseconds.
@@ -133,7 +135,8 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
         IHardwareInfoLogNoiseBuffer? hardwareInfoNoiseBuffer = null,
         IComputeUtilizationReader? computeUtilizationReader = null,
         IGraphicsInventoryReader? graphicsInventoryReader = null,
-        IComputeDeviceIdentityResolver? computeDeviceIdentityResolver = null)
+        IComputeDeviceIdentityResolver? computeDeviceIdentityResolver = null,
+        IDriveInventoryReader? driveInventoryReader = null)
     {
         _frameworkSystem = frameworkSystem;
         _hardwareInfo = hardwareInfo;
@@ -149,6 +152,9 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
         // The same resolver the Windows utilization reader uses for LUID mapping also describes the devices,
         // so the NPU can be listed with a driver and firmware version rather than just a name and a percentage.
         _computeDeviceIdentityResolver = computeDeviceIdentityResolver ?? UnavailableComputeDeviceIdentityResolver.Instance;
+        // Same contract for drives: a platform whose drive enumeration comes from Hardware.Info supplies no
+        // reader here and nothing changes.
+        _driveInventoryReader = driveInventoryReader ?? UnavailableDriveInventoryReader.Instance;
         SystemStatus = _systemStatus;
         FlashSnapshots = _flashSnapshots;
         FanCapabilitiesSnapshots = _fanCapabilitiesSnapshots;
@@ -572,7 +578,17 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
                 _lastStaticInventoryRefreshAt = observedAt;
 
                 TryProbe("refresh the memory list", _hardwareInfo.RefreshMemoryList);
-                TryProbe("refresh the drive list", _hardwareInfo.RefreshDriveList);
+                // Same substitution the graphics reader makes below, and for the same reason: where a platform
+                // reader exists it REPLACES Hardware.Info's enumeration rather than supplementing it, so the
+                // broken shell-out never runs. On Linux that also avoids the lshw probe entirely.
+                if (_driveInventoryReader.IsAvailable)
+                {
+                    TryProbe("read the drive inventory", () => _driveInventory = _driveInventoryReader.Read());
+                }
+                else
+                {
+                    TryProbe("refresh the drive list", _hardwareInfo.RefreshDriveList);
+                }
                 TryProbe("refresh the motherboard list", _hardwareInfo.RefreshMotherboardList);
                 TryProbe("refresh the BIOS list", _hardwareInfo.RefreshBIOSList);
                 TryProbe("refresh the computer system list", _hardwareInfo.RefreshComputerSystemList);
@@ -889,7 +905,11 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
 
         try
         {
-            if (_hardwareInfo.DriveList.Count > 0)
+            if (_driveInventoryReader.IsAvailable)
+            {
+                drives = [.. _driveInventory.Drives];
+            }
+            else if (_hardwareInfo.DriveList.Count > 0)
             {
                 drives = _hardwareInfo.DriveList
                     .Select(drive => new HardwareInfoDrive(

--- a/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
+++ b/SubZeroFramework.Core/Services/FrameworkDataProvider.cs
@@ -68,6 +68,8 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
     private GraphicsInventory _graphicsInventory = GraphicsInventory.Empty;
     private readonly IDriveInventoryReader _driveInventoryReader;
     private DriveInventory _driveInventory = DriveInventory.Empty;
+    private readonly IMemoryInventoryReader _memoryInventoryReader;
+    private MemoryInventory _memoryInventory = MemoryInventory.Empty;
 
     // Compute-accelerator identity (the NPU's model, driver and firmware). Static, so it is resolved on the
     // slow inventory tier and cached here — the Windows resolver alone costs hundreds of milliseconds.
@@ -136,7 +138,8 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
         IComputeUtilizationReader? computeUtilizationReader = null,
         IGraphicsInventoryReader? graphicsInventoryReader = null,
         IComputeDeviceIdentityResolver? computeDeviceIdentityResolver = null,
-        IDriveInventoryReader? driveInventoryReader = null)
+        IDriveInventoryReader? driveInventoryReader = null,
+        IMemoryInventoryReader? memoryInventoryReader = null)
     {
         _frameworkSystem = frameworkSystem;
         _hardwareInfo = hardwareInfo;
@@ -152,9 +155,11 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
         // The same resolver the Windows utilization reader uses for LUID mapping also describes the devices,
         // so the NPU can be listed with a driver and firmware version rather than just a name and a percentage.
         _computeDeviceIdentityResolver = computeDeviceIdentityResolver ?? UnavailableComputeDeviceIdentityResolver.Instance;
-        // Same contract for drives: a platform whose drive enumeration comes from Hardware.Info supplies no
-        // reader here and nothing changes.
+        // Same contract again for drives: a platform whose drive enumeration comes from Hardware.Info supplies
+        // no reader here and nothing changes.
         _driveInventoryReader = driveInventoryReader ?? UnavailableDriveInventoryReader.Instance;
+        // And for memory modules, whose Linux list is both wrong (it keeps lshw's container node) and sparse.
+        _memoryInventoryReader = memoryInventoryReader ?? UnavailableMemoryInventoryReader.Instance;
         SystemStatus = _systemStatus;
         FlashSnapshots = _flashSnapshots;
         FanCapabilitiesSnapshots = _fanCapabilitiesSnapshots;
@@ -577,7 +582,14 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
                 // until the interval elapses would reintroduce exactly the spike this exists to prevent.
                 _lastStaticInventoryRefreshAt = observedAt;
 
-                TryProbe("refresh the memory list", _hardwareInfo.RefreshMemoryList);
+                if (_memoryInventoryReader.IsAvailable)
+                {
+                    TryProbe("read the memory inventory", () => _memoryInventory = _memoryInventoryReader.Read());
+                }
+                else
+                {
+                    TryProbe("refresh the memory list", _hardwareInfo.RefreshMemoryList);
+                }
                 // Same substitution the graphics reader makes below, and for the same reason: where a platform
                 // reader exists it REPLACES Hardware.Info's enumeration rather than supplementing it, so the
                 // broken shell-out never runs. On Linux that also avoids the lshw probe entirely.
@@ -880,7 +892,11 @@ public sealed partial class FrameworkDataProvider : IFrameworkDataProvider, IDis
 
         try
         {
-            if (_hardwareInfo.MemoryList.Count > 0)
+            if (_memoryInventoryReader.IsAvailable)
+            {
+                memoryModules = [.. _memoryInventory.Modules];
+            }
+            else if (_hardwareInfo.MemoryList.Count > 0)
             {
                 memoryModules = _hardwareInfo.MemoryList
                     .Select(memory => new HardwareInfoMemoryModule(

--- a/SubZeroFramework.Core/Services/Linux/LinuxBlockDriveInventoryReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/LinuxBlockDriveInventoryReader.cs
@@ -1,0 +1,363 @@
+using System.Globalization;
+
+using Microsoft.Extensions.Logging;
+
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Linux;
+
+/// <summary>
+/// Enumerates physical drives from the kernel's block tree, without Hardware.Info and without lshw.
+/// </summary>
+/// <remarks>
+/// This is the Linux answer to Hardware.Info's drive list, which cannot describe a real device here: its
+/// Linux implementation returns one synthetic entry built from mount points, with model, serial, firmware and
+/// size all blank. Verified against Hardware.Info.Aot 110.0.0.1 running as root — this is a library gap, not a
+/// privilege problem, so no amount of elevation fixes it.
+///
+/// Everything the UI needs is plain text under <c>/sys/block</c> and is world-readable, so this reader needs no
+/// privileges at all: <c>device/model</c>, <c>device/serial</c>, <c>device/firmware_rev</c>,
+/// <c>queue/rotational</c>, and <c>size</c> (always in 512-byte units regardless of the device's logical block
+/// size).
+///
+/// Free space is the one thing sysfs cannot answer, so it is attributed from the mount table: each mounted
+/// filesystem is traced back to the disk that ultimately backs it, through partitions AND through device-mapper
+/// slaves, so an encrypted root (LUKS: filesystem on <c>/dev/mapper/x</c> → <c>dm-N</c> → partition → disk)
+/// still reports its space against the physical drive rather than vanishing.
+///
+/// The mount table is parsed here rather than through <see cref="DriveInfo.GetDrives"/> because .NET does not
+/// decode the octal escapes the kernel writes into <c>/proc/mounts</c> for space, tab, newline and backslash —
+/// a mount path containing any of them yields a DriveInfo whose name cannot be stat'd, and asking it for
+/// DriveFormat throws. That defect is what made Hardware.Info's whole drive enumeration throw in the first
+/// place; unescaping here means a mount path with a space in it is simply handled.
+///
+/// Everything is best-effort. An unreadable attribute, a disk with no partitions, a mount whose device has
+/// disappeared, and a machine with no block devices at all each degrade the result rather than failing the
+/// inventory refresh.
+/// </remarks>
+/// <summary>
+/// Default kernel paths the drive reader enumerates. Separate from the reader so the primary constructor can
+/// use them as parameter defaults, mirroring <c>DrmSysfs</c>.
+/// </summary>
+public static class BlockSysfs
+{
+    public const string DefaultSysfsBlockRoot = "/sys/block";
+    public const string DefaultProcMountsPath = "/proc/mounts";
+}
+
+public sealed class LinuxBlockDriveInventoryReader(
+    ILogger<LinuxBlockDriveInventoryReader> logger,
+    string sysfsBlockRoot = BlockSysfs.DefaultSysfsBlockRoot,
+    string procMountsPath = BlockSysfs.DefaultProcMountsPath) : IDriveInventoryReader
+{
+    /// <summary>Kernel block size for the <c>size</c> attribute — fixed at 512 bytes, never the device's own.</summary>
+    private const ulong SysfsSectorBytes = 512;
+
+    private bool _loggedReadFailure;
+
+    /// <summary>
+    /// True when a populated block tree exists at the configured root.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT an <c>OperatingSystem.IsLinux()</c> check, for the same reason the DRM reader avoids
+    /// one: this is ordinary file I/O over an injectable root, so gating it on the OS would make the
+    /// enumeration untestable off Linux. Which platforms construct it at all is a DI decision.
+    /// </remarks>
+    public bool IsAvailable => Directory.Exists(sysfsBlockRoot);
+
+    public DriveInventory Read()
+    {
+        if (!IsAvailable)
+        {
+            return DriveInventory.Empty;
+        }
+
+        try
+        {
+            return ReadCore();
+        }
+        catch (Exception exception)
+        {
+            // The inventory tier must survive anything sysfs does; log once so a persistent problem is
+            // visible without a line per refresh.
+            if (!_loggedReadFailure)
+            {
+                _loggedReadFailure = true;
+                logger.LogWarning(exception, "Could not enumerate drives from {BlockPath}; the Storage page will be empty.", sysfsBlockRoot);
+            }
+
+            return DriveInventory.Empty;
+        }
+    }
+
+    private DriveInventory ReadCore()
+    {
+        var diskNames = Directory.EnumerateDirectories(sysfsBlockRoot)
+            .Select(Path.GetFileName)
+            .Where(name => !string.IsNullOrEmpty(name))
+            .Select(name => name!)
+            // A physical device has a "device" link; loop, ram, zram, md and device-mapper nodes do not. That
+            // single test is what keeps the Storage page showing disks rather than every virtual block device.
+            .Where(name => Directory.Exists(Path.Combine(sysfsBlockRoot, name, "device")))
+            .OrderBy(static name => name, StringComparer.Ordinal)
+            .ToList();
+
+        if (diskNames.Count == 0)
+        {
+            return DriveInventory.Empty;
+        }
+
+        var freeSpaceByDisk = ReadFreeSpaceByDisk(diskNames);
+
+        List<HardwareInfoDrive> drives = [];
+        uint index = 0;
+
+        foreach (var diskName in diskNames)
+        {
+            var diskPath = Path.Combine(sysfsBlockRoot, diskName);
+            var model = ReadAttribute(diskPath, "device/model");
+            var isRotational = string.Equals(ReadAttribute(diskPath, "queue/rotational"), "1", StringComparison.Ordinal);
+            var isRemovable = string.Equals(ReadAttribute(diskPath, "removable"), "1", StringComparison.Ordinal);
+            var mediaType = isRemovable
+                ? "Removable"
+                : isRotational ? "HDD" : "SSD";
+
+            drives.Add(new HardwareInfoDrive(
+                Index: index,
+                Name: $"/dev/{diskName}",
+                Model: model,
+                Caption: model ?? $"/dev/{diskName}",
+                Description: isRotational ? "Rotational drive" : "Solid state drive",
+                // NVMe exposes no vendor attribute; SCSI/ATA do. Null rather than a guess derived from the model.
+                Manufacturer: ReadAttribute(diskPath, "device/vendor"),
+                MediaType: mediaType,
+                SerialNumber: ReadAttribute(diskPath, "device/serial"),
+                // NVMe uses firmware_rev, SCSI/ATA use rev.
+                FirmwareRevision: ReadAttribute(diskPath, "device/firmware_rev") ?? ReadAttribute(diskPath, "device/rev"),
+                Size: ReadSizeBytes(diskPath),
+                FreeSpace: freeSpaceByDisk.GetValueOrDefault(diskName)));
+
+            index++;
+        }
+
+        return new DriveInventory { Drives = drives };
+    }
+
+    private ulong ReadSizeBytes(string diskPath)
+        => ulong.TryParse(ReadAttribute(diskPath, "size"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var sectors)
+            ? sectors * SysfsSectorBytes
+            : 0;
+
+    private static string? ReadAttribute(string diskPath, string relativePath)
+    {
+        try
+        {
+            var path = Path.Combine(diskPath, relativePath);
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            // sysfs pads several of these to a fixed width (model in particular), so the raw value is unusable
+            // as a display string.
+            var value = File.ReadAllText(path).Trim();
+            return string.IsNullOrEmpty(value) ? null : value;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Sums the free space of every mounted filesystem against the physical disk that ultimately backs it.
+    /// </summary>
+    private Dictionary<string, ulong> ReadFreeSpaceByDisk(IReadOnlyCollection<string> diskNames)
+    {
+        Dictionary<string, ulong> freeSpaceByDisk = new(StringComparer.Ordinal);
+        // One filesystem can appear at several mount points (bind mounts). Counting its free space once per
+        // mount would inflate the total well past the size of the disk.
+        HashSet<string> countedDevices = new(StringComparer.Ordinal);
+
+        foreach (var (deviceName, mountPoint) in EnumerateMounts())
+        {
+            if (!countedDevices.Add(deviceName))
+            {
+                continue;
+            }
+
+            var owningDisk = ResolveOwningDisk(deviceName, diskNames);
+            if (owningDisk is null)
+            {
+                continue;
+            }
+
+            try
+            {
+                var available = new DriveInfo(mountPoint).AvailableFreeSpace;
+                if (available > 0)
+                {
+                    freeSpaceByDisk[owningDisk] = freeSpaceByDisk.GetValueOrDefault(owningDisk) + (ulong)available;
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or ArgumentException)
+            {
+                // A mount can disappear between reading the table and stat'ing it, and some pseudo-filesystems
+                // refuse the call outright. Neither is a reason to lose the rest of the inventory.
+            }
+        }
+
+        return freeSpaceByDisk;
+    }
+
+    /// <summary>
+    /// Yields (kernel device name, mount point) for every real block-device mount in the table.
+    /// </summary>
+    private IEnumerable<(string DeviceName, string MountPoint)> EnumerateMounts()
+    {
+        string[] lines;
+        try
+        {
+            lines = File.ReadAllLines(procMountsPath);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            yield break;
+        }
+
+        foreach (var line in lines)
+        {
+            var fields = line.Split(' ');
+            if (fields.Length < 2)
+            {
+                continue;
+            }
+
+            var source = Unescape(fields[0]);
+            if (!source.StartsWith("/dev/", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var deviceName = ResolveKernelDeviceName(source);
+            if (deviceName is null)
+            {
+                continue;
+            }
+
+            yield return (deviceName, Unescape(fields[1]));
+        }
+    }
+
+    /// <summary>
+    /// Decodes the octal escapes the kernel writes for space, tab, newline and backslash.
+    /// </summary>
+    /// <remarks>
+    /// .NET's own mount enumeration omits this step, which is why a mount path containing a space produces a
+    /// DriveInfo that throws DriveNotFoundException on any property that stats the path.
+    /// </remarks>
+    internal static string Unescape(string value)
+    {
+        if (!value.Contains('\\', StringComparison.Ordinal))
+        {
+            return value;
+        }
+
+        var builder = new System.Text.StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '\\'
+                && i + 3 < value.Length
+                && IsOctalDigit(value[i + 1])
+                && IsOctalDigit(value[i + 2])
+                && IsOctalDigit(value[i + 3]))
+            {
+                builder.Append((char)(((value[i + 1] - '0') * 64) + ((value[i + 2] - '0') * 8) + (value[i + 3] - '0')));
+                i += 3;
+                continue;
+            }
+
+            builder.Append(value[i]);
+        }
+
+        return builder.ToString();
+
+        static bool IsOctalDigit(char candidate) => candidate is >= '0' and <= '7';
+    }
+
+    /// <summary>
+    /// Turns a <c>/dev</c> path into the kernel's own device name, following symlinks so
+    /// <c>/dev/mapper/cr_root</c> resolves to <c>dm-0</c>.
+    /// </summary>
+    private static string? ResolveKernelDeviceName(string devicePath)
+    {
+        try
+        {
+            var resolved = File.ResolveLinkTarget(devicePath, returnFinalTarget: true)?.FullName ?? devicePath;
+            var name = Path.GetFileName(resolved);
+            return string.IsNullOrEmpty(name) ? null : name;
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Walks from a mounted device to the physical disk backing it: a partition resolves to its parent, and a
+    /// device-mapper node resolves through its slaves (so LUKS and LVM land on the real drive).
+    /// </summary>
+    private string? ResolveOwningDisk(string deviceName, IReadOnlyCollection<string> diskNames, int depth = 0)
+    {
+        // Stacked mappers are legitimate (LVM on LUKS), but the slave graph is attacker-independent kernel
+        // state and a cycle would still hang the refresh, so the walk is bounded.
+        if (depth > 8)
+        {
+            return null;
+        }
+
+        if (diskNames.Contains(deviceName))
+        {
+            return deviceName;
+        }
+
+        // A partition lives beneath its disk: /sys/block/nvme0n1/nvme0n1p2.
+        foreach (var diskName in diskNames)
+        {
+            if (Directory.Exists(Path.Combine(sysfsBlockRoot, diskName, deviceName)))
+            {
+                return diskName;
+            }
+        }
+
+        // Device-mapper and MD nodes name their backing devices under slaves/.
+        var slavesPath = Path.Combine(sysfsBlockRoot, deviceName, "slaves");
+        if (!Directory.Exists(slavesPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            foreach (var slavePath in Directory.EnumerateFileSystemEntries(slavesPath))
+            {
+                var slaveName = Path.GetFileName(slavePath);
+                if (string.IsNullOrEmpty(slaveName))
+                {
+                    continue;
+                }
+
+                if (ResolveOwningDisk(slaveName, diskNames, depth + 1) is { } owningDisk)
+                {
+                    return owningDisk;
+                }
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/SubZeroFramework.Core/Services/Linux/LinuxDmiMemoryInventoryReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/LinuxDmiMemoryInventoryReader.cs
@@ -1,0 +1,319 @@
+using System.Text;
+
+using Microsoft.Extensions.Logging;
+
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Linux;
+
+/// <summary>
+/// Default kernel path to the raw SMBIOS structure table. Separate from the reader so the primary constructor
+/// can use it as a parameter default, mirroring <c>DrmSysfs</c> and <see cref="BlockSysfs"/>.
+/// </summary>
+public static class DmiTables
+{
+    public const string DefaultDmiTablePath = "/sys/firmware/dmi/tables/DMI";
+}
+
+/// <summary>
+/// Enumerates installed memory modules from the firmware's own SMBIOS table, without Hardware.Info or lshw.
+/// </summary>
+/// <remarks>
+/// This is the Linux answer to Hardware.Info's memory list, which is wrong in two separate ways here. It parses
+/// <c>lshw</c> output and keeps the "System Memory" CONTAINER node as though it were a module, so two installed
+/// sticks are reported as three entries — the first being their total, with no form factor and no speed. And it
+/// leaves manufacturer, part number, serial number, bank label, memory type and data width empty even when run
+/// as root.
+///
+/// SMBIOS type 17 ("Memory Device") carries all of it, one structure per physical slot, with no aggregate node
+/// to filter out: capacity, memory type (DDR4/DDR5/LPDDR5), rated and configured speed, data and total width,
+/// form factor, manufacturer, part number, serial number, and both locator strings. Empty slots are present too
+/// and are identified by a zero size, so they are skipped rather than listed as phantom modules.
+///
+/// The table is <c>0400 root</c>, which the service already satisfies; an unprivileged caller gets an empty
+/// inventory rather than an error, matching what Hardware.Info does unprivileged (it also reports nothing).
+///
+/// Parsing is defensive throughout, in the same spirit as the EDID parser: every field read is bounds-checked
+/// against the structure's own declared length before it is touched, the structure walk stops at the end-of-table
+/// marker or the first malformed header rather than running off the buffer, and the string table is scanned
+/// within the buffer only. Firmware tables are not adversarial input, but they are frequently wrong.
+/// </remarks>
+public sealed class LinuxDmiMemoryInventoryReader(
+    ILogger<LinuxDmiMemoryInventoryReader> logger,
+    string dmiTablePath = DmiTables.DefaultDmiTablePath) : IMemoryInventoryReader
+{
+    /// <summary>SMBIOS structure type for a Memory Device.</summary>
+    private const byte MemoryDeviceType = 17;
+
+    /// <summary>SMBIOS structure type marking the end of the table.</summary>
+    private const byte EndOfTableType = 127;
+
+    /// <summary>Every SMBIOS structure begins with type, length, and a two-byte handle.</summary>
+    private const int StructureHeaderLength = 4;
+
+    private bool _loggedReadFailure;
+
+    /// <summary>
+    /// True when the firmware published a structure table at the configured path.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately NOT an <c>OperatingSystem.IsLinux()</c> check, and deliberately not a readability probe:
+    /// this is ordinary file I/O over an injectable path so the parse stays testable off Linux, and the
+    /// property is consulted on every snapshot, so it must stay cheap. An unreadable table degrades to an
+    /// empty inventory inside <see cref="Read"/>.
+    /// </remarks>
+    public bool IsAvailable => File.Exists(dmiTablePath);
+
+    public MemoryInventory Read()
+    {
+        if (!IsAvailable)
+        {
+            return MemoryInventory.Empty;
+        }
+
+        try
+        {
+            return new MemoryInventory { Modules = ParseMemoryDevices(File.ReadAllBytes(dmiTablePath)) };
+        }
+        catch (Exception exception)
+        {
+            // The inventory tier must survive anything firmware does; log once so a persistent problem is
+            // visible without a line per refresh. UnauthorizedAccessException is the ordinary unprivileged
+            // case and is not worth a warning every time.
+            if (!_loggedReadFailure)
+            {
+                _loggedReadFailure = true;
+                logger.LogWarning(exception, "Could not enumerate memory modules from {DmiPath}; the Memory page will be empty.", dmiTablePath);
+            }
+
+            return MemoryInventory.Empty;
+        }
+    }
+
+    private static List<HardwareInfoMemoryModule> ParseMemoryDevices(byte[] table)
+    {
+        List<HardwareInfoMemoryModule> modules = [];
+        var offset = 0;
+
+        while (offset + StructureHeaderLength <= table.Length)
+        {
+            var structureType = table[offset];
+            int structureLength = table[offset + 1];
+
+            // A structure shorter than its own header, or one that claims to extend past the table, means the
+            // table is malformed. Stop rather than guess.
+            if (structureLength < StructureHeaderLength || offset + structureLength > table.Length)
+            {
+                break;
+            }
+
+            var stringTableStart = offset + structureLength;
+            var nextStructure = SkipStringTable(table, stringTableStart);
+
+            if (structureType == EndOfTableType)
+            {
+                break;
+            }
+
+            if (structureType == MemoryDeviceType
+                && ParseMemoryDevice(table, offset, structureLength, stringTableStart) is { } module)
+            {
+                modules.Add(module);
+            }
+
+            // A string table that ran to the end of the buffer cannot be followed by another structure.
+            if (nextStructure <= offset)
+            {
+                break;
+            }
+
+            offset = nextStructure;
+        }
+
+        return modules;
+    }
+
+    /// <summary>
+    /// Returns the offset just past the double-NUL that terminates a structure's string table.
+    /// </summary>
+    private static int SkipStringTable(byte[] table, int start)
+    {
+        var index = start;
+        while (index + 1 < table.Length && (table[index] != 0 || table[index + 1] != 0))
+        {
+            index++;
+        }
+
+        return index + 2;
+    }
+
+    private static HardwareInfoMemoryModule? ParseMemoryDevice(byte[] table, int offset, int structureLength, int stringTableStart)
+    {
+        // Every accessor below is bounds-checked against the structure's DECLARED length, not the buffer: an
+        // SMBIOS 2.1 table legitimately stops before the fields added in 2.3 and 2.7, and reading past the
+        // declared length would return a neighbouring structure's bytes rather than "unknown".
+        byte ReadByte(int fieldOffset)
+            => fieldOffset < structureLength ? table[offset + fieldOffset] : (byte)0;
+
+        ushort ReadWord(int fieldOffset)
+            => fieldOffset + 1 < structureLength
+                ? (ushort)(table[offset + fieldOffset] | (table[offset + fieldOffset + 1] << 8))
+                : (ushort)0;
+
+        uint ReadDword(int fieldOffset)
+            => fieldOffset + 3 < structureLength
+                ? (uint)(table[offset + fieldOffset]
+                    | (table[offset + fieldOffset + 1] << 8)
+                    | (table[offset + fieldOffset + 2] << 16)
+                    | (table[offset + fieldOffset + 3] << 24))
+                : 0;
+
+        var capacityBytes = ReadCapacityBytes(ReadWord(0x0C), ReadDword(0x1C));
+
+        // A zero size means the slot is present but empty. Listing those is what makes a two-stick machine
+        // appear to have four modules; they are not installed memory and are omitted.
+        if (capacityBytes == 0)
+        {
+            return null;
+        }
+
+        // Rated speed first, configured speed as the fallback, so a module reports the speed it is specified
+        // for (matching what dmidecode and lshw show) rather than the lower rate a mismatched pair runs at.
+        var speed = ReadWord(0x15);
+        if (speed == 0)
+        {
+            speed = ReadWord(0x20);
+        }
+
+        return new HardwareInfoMemoryModule(
+            BankLabel: ReadString(table, stringTableStart, ReadByte(0x11)),
+            CapacityBytes: capacityBytes,
+            DataWidth: NormalizeWidth(ReadWord(0x0A)),
+            MemoryType: DescribeMemoryType(ReadByte(0x12)),
+            FormFactor: DescribeFormFactor(ReadByte(0x0E)),
+            SpeedMHz: speed,
+            MaxVoltage: ReadWord(0x24),
+            MinVoltage: ReadWord(0x22),
+            Manufacturer: ReadString(table, stringTableStart, ReadByte(0x17)),
+            PartNumber: ReadString(table, stringTableStart, ReadByte(0x1A)),
+            SerialNumber: ReadString(table, stringTableStart, ReadByte(0x18)));
+    }
+
+    /// <summary>
+    /// Decodes the type 17 size field, including the 2.7 extended form used above 32 GB per module.
+    /// </summary>
+    internal static ulong ReadCapacityBytes(ushort sizeField, uint extendedSize)
+    {
+        const ushort NotInstalled = 0;
+        const ushort UnknownSize = 0xFFFF;
+        const ushort UseExtendedSize = 0x7FFF;
+
+        if (sizeField is NotInstalled or UnknownSize)
+        {
+            return 0;
+        }
+
+        if (sizeField == UseExtendedSize)
+        {
+            // Bit 31 is reserved; the remainder is a megabyte count.
+            return (ulong)(extendedSize & 0x7FFFFFFF) * 1024UL * 1024UL;
+        }
+
+        // Bit 15 selects the unit: set means kilobytes, clear means megabytes.
+        var magnitude = (ulong)(sizeField & 0x7FFF);
+        return (sizeField & 0x8000) != 0
+            ? magnitude * 1024UL
+            : magnitude * 1024UL * 1024UL;
+    }
+
+    /// <summary>0xFFFF is SMBIOS for "unknown"; the model represents that as zero.</summary>
+    private static uint NormalizeWidth(ushort width) => width == 0xFFFF ? 0u : width;
+
+    /// <summary>
+    /// Reads a 1-based string-table entry. Index 0 means the field was not populated.
+    /// </summary>
+    internal static string? ReadString(byte[] table, int stringTableStart, byte index)
+    {
+        if (index == 0 || stringTableStart >= table.Length)
+        {
+            return null;
+        }
+
+        var position = stringTableStart;
+        var current = 1;
+
+        while (position < table.Length)
+        {
+            var start = position;
+            while (position < table.Length && table[position] != 0)
+            {
+                position++;
+            }
+
+            // An empty entry is the table terminator, so the requested index does not exist.
+            if (position == start)
+            {
+                return null;
+            }
+
+            if (current == index)
+            {
+                // SMBIOS strings are 7-bit ASCII in practice, but Latin-1 decodes any byte without throwing
+                // and firmware does occasionally pad with high bytes.
+                var value = Encoding.Latin1.GetString(table, start, position - start).Trim();
+                return string.IsNullOrEmpty(value) ? null : value;
+            }
+
+            current++;
+            position++;
+        }
+
+        return null;
+    }
+
+    /// <summary>SMBIOS 7.18.2 Memory Device — Form Factor.</summary>
+    private static string? DescribeFormFactor(byte formFactor) => formFactor switch
+    {
+        0x03 => "SIMM",
+        0x04 => "SIP",
+        0x05 => "Chip",
+        0x06 => "DIP",
+        0x07 => "ZIP",
+        0x08 => "Proprietary Card",
+        0x09 => "DIMM",
+        0x0A => "TSOP",
+        0x0B => "Row of chips",
+        0x0C => "RIMM",
+        0x0D => "SODIMM",
+        0x0E => "SRIMM",
+        0x0F => "FB-DIMM",
+        0x10 => "Die",
+        // 0x01 Other and 0x02 Unknown carry no more information than saying nothing does.
+        _ => null,
+    };
+
+    /// <summary>SMBIOS 7.18.3 Memory Device — Memory Type.</summary>
+    private static string? DescribeMemoryType(byte memoryType) => memoryType switch
+    {
+        0x03 => "DRAM",
+        0x0F => "SDRAM",
+        0x11 => "SDRAM",
+        0x12 => "DDR",
+        0x13 => "DDR2",
+        0x14 => "DDR2 FB-DIMM",
+        0x18 => "DDR3",
+        0x19 => "FBD2",
+        0x1A => "DDR4",
+        0x1B => "LPDDR",
+        0x1C => "LPDDR2",
+        0x1D => "LPDDR3",
+        0x1E => "LPDDR4",
+        0x1F => "Logical non-volatile device",
+        0x20 => "HBM",
+        0x21 => "HBM2",
+        0x22 => "DDR5",
+        0x23 => "LPDDR5",
+        0x24 => "HBM3",
+        _ => null,
+    };
+}

--- a/SubZeroFramework.Core/Services/Linux/UnavailableDriveInventoryReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/UnavailableDriveInventoryReader.cs
@@ -1,0 +1,20 @@
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Linux;
+
+/// <summary>
+/// Null object for platforms that get their drive inventory from Hardware.Info (Windows), so the provider
+/// never branches on null.
+/// </summary>
+public sealed class UnavailableDriveInventoryReader : IDriveInventoryReader
+{
+    public static UnavailableDriveInventoryReader Instance { get; } = new();
+
+    private UnavailableDriveInventoryReader()
+    {
+    }
+
+    public bool IsAvailable => false;
+
+    public DriveInventory Read() => DriveInventory.Empty;
+}

--- a/SubZeroFramework.Core/Services/Linux/UnavailableMemoryInventoryReader.cs
+++ b/SubZeroFramework.Core/Services/Linux/UnavailableMemoryInventoryReader.cs
@@ -1,0 +1,20 @@
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Linux;
+
+/// <summary>
+/// Null object for platforms that get their memory inventory from Hardware.Info (Windows), so the provider
+/// never branches on null.
+/// </summary>
+public sealed class UnavailableMemoryInventoryReader : IMemoryInventoryReader
+{
+    public static UnavailableMemoryInventoryReader Instance { get; } = new();
+
+    private UnavailableMemoryInventoryReader()
+    {
+    }
+
+    public bool IsAvailable => false;
+
+    public MemoryInventory Read() => MemoryInventory.Empty;
+}

--- a/SubZeroFramework.Core/SubZeroFramework.Core.csproj
+++ b/SubZeroFramework.Core/SubZeroFramework.Core.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SubZeroFramework.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="DynamicData" />
     <PackageReference Include="FrameworkDotnet" />
     <PackageReference Include="Hardware.Info.Aot" />

--- a/SubZeroFramework.Service/Program.cs
+++ b/SubZeroFramework.Service/Program.cs
@@ -112,6 +112,7 @@ public static class Program
         builder.Services.AddSingleton<IComputeDeviceIdentityResolver, WindowsComputeDeviceIdentityResolver>();
         builder.Services.AddSingleton<IComputeUtilizationReader, WindowsPdhComputeUtilizationReader>();
         builder.Services.AddSingleton<IGraphicsInventoryReader>(UnavailableGraphicsInventoryReader.Instance);
+        builder.Services.AddSingleton<IDriveInventoryReader>(UnavailableDriveInventoryReader.Instance);
 #else
         // Linux has no single counter set covering every vendor the way Windows' GPU Engine does, so each
         // source is its own reader and a composite merges them: a Framework 16 with the graphics module
@@ -133,12 +134,16 @@ public static class Program
 
             // Replaces Hardware.Info's xrandr-based enumeration, which cannot work without a display server.
             builder.Services.AddSingleton<IGraphicsInventoryReader, LinuxDrmGraphicsInventoryReader>();
+            // Replaces Hardware.Info's drive list, whose Linux implementation describes mount points rather
+            // than devices and leaves every hardware field blank.
+            builder.Services.AddSingleton<IDriveInventoryReader, LinuxBlockDriveInventoryReader>();
             builder.Services.AddSingleton<IComputeDeviceIdentityResolver, LinuxComputeDeviceIdentityResolver>();
         }
         else
         {
             builder.Services.AddSingleton<IComputeUtilizationReader>(UnavailableComputeUtilizationReader.Instance);
             builder.Services.AddSingleton<IGraphicsInventoryReader>(UnavailableGraphicsInventoryReader.Instance);
+            builder.Services.AddSingleton<IDriveInventoryReader>(UnavailableDriveInventoryReader.Instance);
             builder.Services.AddSingleton<IComputeDeviceIdentityResolver>(UnavailableComputeDeviceIdentityResolver.Instance);
         }
 #endif

--- a/SubZeroFramework.Service/Program.cs
+++ b/SubZeroFramework.Service/Program.cs
@@ -113,6 +113,7 @@ public static class Program
         builder.Services.AddSingleton<IComputeUtilizationReader, WindowsPdhComputeUtilizationReader>();
         builder.Services.AddSingleton<IGraphicsInventoryReader>(UnavailableGraphicsInventoryReader.Instance);
         builder.Services.AddSingleton<IDriveInventoryReader>(UnavailableDriveInventoryReader.Instance);
+        builder.Services.AddSingleton<IMemoryInventoryReader>(UnavailableMemoryInventoryReader.Instance);
 #else
         // Linux has no single counter set covering every vendor the way Windows' GPU Engine does, so each
         // source is its own reader and a composite merges them: a Framework 16 with the graphics module
@@ -137,6 +138,9 @@ public static class Program
             // Replaces Hardware.Info's drive list, whose Linux implementation describes mount points rather
             // than devices and leaves every hardware field blank.
             builder.Services.AddSingleton<IDriveInventoryReader, LinuxBlockDriveInventoryReader>();
+            // Replaces Hardware.Info's memory list, which keeps lshw's "System Memory" container node as a
+            // phantom module and leaves every identifying field blank.
+            builder.Services.AddSingleton<IMemoryInventoryReader, LinuxDmiMemoryInventoryReader>();
             builder.Services.AddSingleton<IComputeDeviceIdentityResolver, LinuxComputeDeviceIdentityResolver>();
         }
         else
@@ -144,6 +148,7 @@ public static class Program
             builder.Services.AddSingleton<IComputeUtilizationReader>(UnavailableComputeUtilizationReader.Instance);
             builder.Services.AddSingleton<IGraphicsInventoryReader>(UnavailableGraphicsInventoryReader.Instance);
             builder.Services.AddSingleton<IDriveInventoryReader>(UnavailableDriveInventoryReader.Instance);
+            builder.Services.AddSingleton<IMemoryInventoryReader>(UnavailableMemoryInventoryReader.Instance);
             builder.Services.AddSingleton<IComputeDeviceIdentityResolver>(UnavailableComputeDeviceIdentityResolver.Instance);
         }
 #endif

--- a/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
+++ b/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
@@ -19,8 +19,15 @@ namespace SubZeroFramework.Tests;
 /// That last case is the one that started this: the kernel escapes a space as <c>\040</c> in
 /// <c>/proc/mounts</c>, .NET's own mount enumeration does not decode it, and the resulting DriveInfo throws
 /// when asked for anything that stats the path — which is what made Hardware.Info's entire drive list throw.
+///
+/// Gated to Linux despite the tree being synthetic. Free-space attribution goes through
+/// <see cref="DriveInfo"/>, whose constructor accepts a mount point on Unix but requires a drive ROOT on
+/// Windows, so the space assertions describe Unix semantics rather than the parse itself. The parsing tests
+/// alongside them would pass anywhere; they are gated with the rest rather than split, so the fixture has one
+/// platform story instead of two.
 /// </remarks>
 [TestFixture]
+[Platform("Linux")]
 public class LinuxBlockDriveInventoryReaderTests
 {
     private string _root = string.Empty;

--- a/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
+++ b/SubZeroFramework.Tests/LinuxBlockDriveInventoryReaderTests.cs
@@ -1,0 +1,202 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NUnit.Framework;
+
+using SubZeroFramework.Services.Linux;
+
+namespace SubZeroFramework.Tests;
+
+/// <summary>
+/// Exercises the Linux block enumeration against a synthetic sysfs tree and mount table.
+/// </summary>
+/// <remarks>
+/// The reader takes its sysfs root and mount-table path as constructor arguments precisely so this is
+/// possible: the layout of <c>/sys/block</c> is stable and documented, so a fixture tree reproduces it
+/// faithfully and covers what would otherwise need several machines — an NVMe SSD and a rotational SATA disk,
+/// a LUKS volume whose filesystem sits on a device-mapper node rather than the partition, virtual block
+/// devices that must be excluded, and a mount path containing a space.
+///
+/// That last case is the one that started this: the kernel escapes a space as <c>\040</c> in
+/// <c>/proc/mounts</c>, .NET's own mount enumeration does not decode it, and the resulting DriveInfo throws
+/// when asked for anything that stats the path — which is what made Hardware.Info's entire drive list throw.
+/// </remarks>
+[TestFixture]
+public class LinuxBlockDriveInventoryReaderTests
+{
+    private string _root = string.Empty;
+    private string _mounts = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "szf-block-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _mounts = Path.Combine(_root, "mounts");
+        File.WriteAllText(_mounts, string.Empty);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private LinuxBlockDriveInventoryReader CreateReader()
+        => new(NullLogger<LinuxBlockDriveInventoryReader>.Instance, _root, _mounts);
+
+    private void WriteAttribute(string relativePath, string value)
+    {
+        var path = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, value);
+    }
+
+    /// <summary>An NVMe SSD, padded exactly the way sysfs pads the model field.</summary>
+    private void GivenNvmeDisk(string name = "nvme0n1", string sectors = "1953525168")
+    {
+        WriteAttribute($"{name}/device/model", "CT1000P3PSSD8                           \n");
+        WriteAttribute($"{name}/device/serial", "24514CFE212E        \n");
+        WriteAttribute($"{name}/device/firmware_rev", "P9CR413 \n");
+        WriteAttribute($"{name}/queue/rotational", "0\n");
+        WriteAttribute($"{name}/removable", "0\n");
+        WriteAttribute($"{name}/size", sectors + "\n");
+    }
+
+    [Test]
+    public void Read_WhenBlockRootMissing_ReportsUnavailableAndEmpty()
+    {
+        var reader = new LinuxBlockDriveInventoryReader(
+            NullLogger<LinuxBlockDriveInventoryReader>.Instance,
+            Path.Combine(_root, "does-not-exist"),
+            _mounts);
+
+        Assert.That(reader.IsAvailable, Is.False);
+        Assert.That(reader.Read().IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Read_PopulatesHardwareFieldsFromSysfs()
+    {
+        GivenNvmeDisk();
+
+        var drive = CreateReader().Read().Drives.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(drive.Name, Is.EqualTo("/dev/nvme0n1"));
+            // sysfs pads these to a fixed width; the reader must not surface the padding.
+            Assert.That(drive.Model, Is.EqualTo("CT1000P3PSSD8"));
+            Assert.That(drive.SerialNumber, Is.EqualTo("24514CFE212E"));
+            Assert.That(drive.FirmwareRevision, Is.EqualTo("P9CR413"));
+            Assert.That(drive.MediaType, Is.EqualTo("SSD"));
+            // The size attribute is always in 512-byte units, never the device's logical block size.
+            Assert.That(drive.Size, Is.EqualTo(1953525168UL * 512UL));
+        });
+    }
+
+    [Test]
+    public void Read_WhenDiskIsRotational_ReportsHdd()
+    {
+        GivenNvmeDisk("sda");
+        WriteAttribute("sda/queue/rotational", "1\n");
+        // SCSI and ATA expose "rev" where NVMe exposes "firmware_rev".
+        File.Delete(Path.Combine(_root, "sda/device/firmware_rev"));
+        WriteAttribute("sda/device/rev", "SB10\n");
+
+        var drive = CreateReader().Read().Drives.Single();
+
+        Assert.That(drive.MediaType, Is.EqualTo("HDD"));
+        Assert.That(drive.FirmwareRevision, Is.EqualTo("SB10"));
+    }
+
+    [Test]
+    public void Read_ExcludesVirtualBlockDevices()
+    {
+        GivenNvmeDisk();
+        // loop, zram and device-mapper nodes have no "device" link — that is the whole test for exclusion.
+        Directory.CreateDirectory(Path.Combine(_root, "loop0"));
+        Directory.CreateDirectory(Path.Combine(_root, "zram0"));
+        Directory.CreateDirectory(Path.Combine(_root, "dm-0"));
+
+        var drives = CreateReader().Read().Drives;
+
+        Assert.That(drives.Select(drive => drive.Name), Is.EqualTo(new[] { "/dev/nvme0n1" }));
+    }
+
+    [Test]
+    public void Read_WhenMountPathContainsEscapedSpace_DoesNotThrow()
+    {
+        GivenNvmeDisk();
+        Directory.CreateDirectory(Path.Combine(_root, "nvme0n1", "nvme0n1p1"));
+        WriteAttribute("nvme0n1/nvme0n1p1/partition", "1\n");
+        // The kernel writes a space as \040. Decoding it is the reader's job; .NET's own enumeration omits it.
+        File.WriteAllText(_mounts, "/dev/nvme0n1p1 /mnt/Google\\040Drive ext4 rw 0 0\n");
+
+        var drives = CreateReader().Read().Drives;
+
+        Assert.That(drives, Has.Count.EqualTo(1));
+        Assert.That(drives[0].Model, Is.EqualTo("CT1000P3PSSD8"));
+    }
+
+    [TestCase("plain", "plain")]
+    [TestCase("with\\040space", "with space")]
+    [TestCase("tab\\011here", "tab\there")]
+    [TestCase("back\\134slash", "back\\slash")]
+    [TestCase("trailing\\", "trailing\\")]
+    [TestCase("\\04", "\\04")]
+    public void Unescape_DecodesOctalSequencesAndLeavesEverythingElseAlone(string input, string expected)
+        => Assert.That(LinuxBlockDriveInventoryReader.Unescape(input), Is.EqualTo(expected));
+
+    [Test]
+    public void Read_AttributesFreeSpaceThroughDeviceMapperSlaves()
+    {
+        GivenNvmeDisk();
+        Directory.CreateDirectory(Path.Combine(_root, "nvme0n1", "nvme0n1p2"));
+        WriteAttribute("nvme0n1/nvme0n1p2/partition", "2\n");
+        // A LUKS volume: the filesystem is mounted on the mapper node, which names its backing partition
+        // under slaves/. Without the walk the space would be attributed to no disk at all.
+        Directory.CreateDirectory(Path.Combine(_root, "dm-0", "slaves", "nvme0n1p2"));
+
+        // The mount point must exist for the free-space stat to succeed; the reader is expected to survive
+        // either way, so this asserts the resolution reached the disk rather than a specific byte count.
+        var mountPoint = Path.Combine(_root, "mnt");
+        Directory.CreateDirectory(mountPoint);
+        File.WriteAllText(_mounts, $"/dev/dm-0 {mountPoint.Replace(" ", "\\040")} btrfs rw 0 0\n");
+
+        var drive = CreateReader().Read().Drives.Single();
+
+        Assert.That(drive.Name, Is.EqualTo("/dev/nvme0n1"));
+        Assert.That(drive.FreeSpace, Is.GreaterThan(0UL), "free space should be traced through dm-0 to its backing disk");
+    }
+
+    [Test]
+    public void Read_CountsAFilesystemOnceAcrossManyMountPoints()
+    {
+        GivenNvmeDisk();
+        Directory.CreateDirectory(Path.Combine(_root, "nvme0n1", "nvme0n1p2"));
+        WriteAttribute("nvme0n1/nvme0n1p2/partition", "2\n");
+
+        var mountPoint = Path.Combine(_root, "mnt");
+        Directory.CreateDirectory(mountPoint);
+
+        // btrfs subvolumes surface as many mounts of ONE filesystem. Summing per mount would report multiple
+        // times the disk's real free space — on the machine this was written against, 1.18 TB on a 931 GB SSD.
+        var singleMount = $"/dev/nvme0n1p2 {mountPoint} btrfs rw 0 0\n";
+        File.WriteAllText(_mounts, singleMount);
+        var oneMountFreeSpace = CreateReader().Read().Drives.Single().FreeSpace;
+
+        File.WriteAllText(_mounts, string.Concat(Enumerable.Repeat(singleMount, 9)));
+        var nineMountFreeSpace = CreateReader().Read().Drives.Single().FreeSpace;
+
+        Assert.That(nineMountFreeSpace, Is.EqualTo(oneMountFreeSpace));
+    }
+}

--- a/SubZeroFramework.Tests/LinuxDmiMemoryInventoryReaderTests.cs
+++ b/SubZeroFramework.Tests/LinuxDmiMemoryInventoryReaderTests.cs
@@ -18,8 +18,14 @@ namespace SubZeroFramework.Tests;
 /// The empty-slot case is the one that motivated this reader: firmware publishes a structure for every socket
 /// whether or not it holds a module, and Hardware.Info compounded that by also reporting lshw's container node,
 /// so a two-stick machine listed three modules.
+///
+/// Gated to Linux at the maintainer's request. Nothing in the parse itself is platform-specific — the table
+/// is a byte array and the fixtures are hand-built — but the reader exists only for the Linux DI branch, and
+/// /sys/firmware/dmi/tables/DMI is the Linux path to SMBIOS, so the fixture is marked with the reader it
+/// covers rather than left running against a table layout that platform never reads this way.
 /// </remarks>
 [TestFixture]
+[Platform("Linux")]
 public class LinuxDmiMemoryInventoryReaderTests
 {
     private string _tablePath = string.Empty;

--- a/SubZeroFramework.Tests/LinuxDmiMemoryInventoryReaderTests.cs
+++ b/SubZeroFramework.Tests/LinuxDmiMemoryInventoryReaderTests.cs
@@ -1,0 +1,273 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NUnit.Framework;
+
+using SubZeroFramework.Services.Linux;
+
+namespace SubZeroFramework.Tests;
+
+/// <summary>
+/// Exercises the SMBIOS type 17 parse against synthetic structure tables.
+/// </summary>
+/// <remarks>
+/// The reader takes its table path as a constructor argument so the parse can be driven from a fixture: SMBIOS
+/// is a published, stable binary layout, so a hand-built table reproduces what firmware emits and covers what
+/// would otherwise need a pile of different machines — a populated slot beside an empty one, the pre-2.7 size
+/// encoding beside the extended one, a truncated 2.1-era structure, and a table with no memory devices at all.
+///
+/// The empty-slot case is the one that motivated this reader: firmware publishes a structure for every socket
+/// whether or not it holds a module, and Hardware.Info compounded that by also reporting lshw's container node,
+/// so a two-stick machine listed three modules.
+/// </remarks>
+[TestFixture]
+public class LinuxDmiMemoryInventoryReaderTests
+{
+    private string _tablePath = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+        => _tablePath = Path.Combine(Path.GetTempPath(), "szf-dmi-" + Guid.NewGuid().ToString("N"));
+
+    [TearDown]
+    public void TearDown()
+    {
+        try
+        {
+            if (File.Exists(_tablePath))
+            {
+                File.Delete(_tablePath);
+            }
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private LinuxDmiMemoryInventoryReader CreateReader()
+        => new(NullLogger<LinuxDmiMemoryInventoryReader>.Instance, _tablePath);
+
+    /// <summary>
+    /// Builds one SMBIOS type 17 structure. Field offsets follow SMBIOS 7.18; the structure is emitted at the
+    /// full 2.8 length so every field the reader knows about is present.
+    /// </summary>
+    private static byte[] MemoryDevice(
+        ushort sizeField,
+        uint extendedSize = 0,
+        ushort speed = 3200,
+        byte memoryType = 0x22,
+        byte formFactor = 0x0D,
+        ushort dataWidth = 64,
+        string? deviceLocator = "Controller0-ChannelA",
+        string? bankLocator = "BANK 0",
+        string? manufacturer = "Crucial",
+        string? serial = "E7DF1A22",
+        string? partNumber = "CT32G56C46S5.M8G1")
+    {
+        const int StructureLength = 0x28;
+        var body = new byte[StructureLength];
+        body[0] = 17;                       // type
+        body[1] = StructureLength;          // length
+        body[2] = 0x10;                     // handle low
+        body[3] = 0x00;                     // handle high
+
+        void WriteWord(int offset, ushort value)
+        {
+            body[offset] = (byte)(value & 0xFF);
+            body[offset + 1] = (byte)(value >> 8);
+        }
+
+        WriteWord(0x08, 64);                // total width
+        WriteWord(0x0A, dataWidth);
+        WriteWord(0x0C, sizeField);
+        body[0x0E] = formFactor;
+        body[0x10] = 1;                     // device locator -> string 1
+        body[0x11] = 2;                     // bank locator   -> string 2
+        body[0x12] = memoryType;
+        WriteWord(0x15, speed);
+        body[0x17] = 3;                     // manufacturer   -> string 3
+        body[0x18] = 4;                     // serial         -> string 4
+        body[0x1A] = 5;                     // part number    -> string 5
+        body[0x1C] = (byte)(extendedSize & 0xFF);
+        body[0x1D] = (byte)((extendedSize >> 8) & 0xFF);
+        body[0x1E] = (byte)((extendedSize >> 16) & 0xFF);
+        body[0x1F] = (byte)((extendedSize >> 24) & 0xFF);
+        WriteWord(0x22, 1100);              // min voltage (mV)
+        WriteWord(0x24, 1100);              // max voltage (mV)
+
+        return [.. body, .. StringTable(deviceLocator, bankLocator, manufacturer, serial, partNumber)];
+    }
+
+    /// <summary>A structure's trailing string table: NUL-separated entries closed by a double NUL.</summary>
+    private static byte[] StringTable(params string?[] values)
+    {
+        List<byte> bytes = [];
+        foreach (var value in values)
+        {
+            bytes.AddRange(System.Text.Encoding.ASCII.GetBytes(value ?? string.Empty));
+            bytes.Add(0);
+        }
+
+        // A structure with no strings is still terminated by two NULs.
+        if (values.Length == 0)
+        {
+            bytes.Add(0);
+        }
+
+        bytes.Add(0);
+        return [.. bytes];
+    }
+
+    /// <summary>The end-of-table marker every real table closes with.</summary>
+    private static byte[] EndOfTable() => [127, 4, 0x20, 0x00, 0x00, 0x00];
+
+    private void WriteTable(params byte[][] structures)
+        => File.WriteAllBytes(_tablePath, structures.SelectMany(static structure => structure).ToArray());
+
+    [Test]
+    public void Read_WhenTableMissing_ReportsUnavailableAndEmpty()
+    {
+        var reader = CreateReader();
+
+        Assert.That(reader.IsAvailable, Is.False);
+        Assert.That(reader.Read().IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Read_PopulatesEveryFieldFromTheStructure()
+    {
+        // 16384 MB is the largest power-of-two capacity still expressible in the plain megabyte form: bit 15
+        // is the kilobyte flag, so 32768 would decode as "0 KB" rather than 32 GB. Anything that size or
+        // larger has to use the extended field, which Read_DecodesExtendedSizeForLargeModules covers.
+        WriteTable(MemoryDevice(sizeField: 16384), EndOfTable());
+
+        var module = CreateReader().Read().Modules.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(module.CapacityBytes, Is.EqualTo(16384UL * 1024UL * 1024UL));
+            Assert.That(module.MemoryType, Is.EqualTo("DDR5"));
+            Assert.That(module.FormFactor, Is.EqualTo("SODIMM"));
+            Assert.That(module.SpeedMHz, Is.EqualTo(3200));
+            Assert.That(module.DataWidth, Is.EqualTo(64));
+            Assert.That(module.BankLabel, Is.EqualTo("BANK 0"));
+            Assert.That(module.Manufacturer, Is.EqualTo("Crucial"));
+            Assert.That(module.SerialNumber, Is.EqualTo("E7DF1A22"));
+            Assert.That(module.PartNumber, Is.EqualTo("CT32G56C46S5.M8G1"));
+            Assert.That(module.MinVoltage, Is.EqualTo(1100));
+        });
+    }
+
+    [Test]
+    public void Read_OmitsEmptySlots()
+    {
+        // Firmware publishes a structure per socket. A zero size means the socket is empty — listing it is
+        // exactly the phantom-module bug this reader exists to avoid.
+        // Mirrors the machine this was written against: a 32 GB stick (extended size, since it exceeds what the
+        // megabyte form can express), an empty socket, and a 16 GB stick.
+        WriteTable(
+            MemoryDevice(sizeField: 0x7FFF, extendedSize: 32768),
+            MemoryDevice(sizeField: 0),
+            MemoryDevice(sizeField: 16384),
+            EndOfTable());
+
+        var modules = CreateReader().Read().Modules;
+
+        Assert.That(modules, Has.Count.EqualTo(2));
+        Assert.That(
+            modules.Sum(module => (long)module.CapacityBytes),
+            Is.EqualTo(48L * 1024 * 1024 * 1024),
+            "the two installed sticks should total 48 GiB with no aggregate entry");
+    }
+
+    [Test]
+    public void Read_DecodesKilobyteScaledSizes()
+    {
+        // Bit 15 set means the value is in kilobytes rather than megabytes.
+        WriteTable(MemoryDevice(sizeField: 0x8000 | 512), EndOfTable());
+
+        Assert.That(CreateReader().Read().Modules.Single().CapacityBytes, Is.EqualTo(512UL * 1024UL));
+    }
+
+    [Test]
+    public void Read_DecodesExtendedSizeForLargeModules()
+    {
+        // 0x7FFF redirects to the 2.7 extended dword, which is how modules above 32 GB are expressed.
+        WriteTable(MemoryDevice(sizeField: 0x7FFF, extendedSize: 65536), EndOfTable());
+
+        Assert.That(CreateReader().Read().Modules.Single().CapacityBytes, Is.EqualTo(64UL * 1024 * 1024 * 1024));
+    }
+
+    [Test]
+    public void Read_WhenSizeIsUnknown_OmitsTheModule()
+    {
+        WriteTable(MemoryDevice(sizeField: 0xFFFF), EndOfTable());
+
+        Assert.That(CreateReader().Read().IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Read_WhenStructureIsTruncatedBeforeLaterFields_StillReportsWhatIsPresent()
+    {
+        // An SMBIOS 2.1 structure legitimately ends before speed, manufacturer and the rest. Those fields must
+        // read as unknown rather than picking up the neighbouring structure's bytes.
+        var truncated = MemoryDevice(sizeField: 16384)[..0x15];
+        truncated[1] = 0x15;
+
+        WriteTable([.. truncated, .. StringTable()], EndOfTable());
+
+        var module = CreateReader().Read().Modules.Single();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(module.CapacityBytes, Is.EqualTo(16384UL * 1024UL * 1024UL));
+            Assert.That(module.FormFactor, Is.EqualTo("SODIMM"));
+            Assert.That(module.SpeedMHz, Is.Zero);
+            Assert.That(module.PartNumber, Is.Null);
+            Assert.That(module.SerialNumber, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Read_StopsAtEndOfTableMarker()
+    {
+        // Anything after the 127 marker is not part of the table and must not be parsed.
+        WriteTable(MemoryDevice(sizeField: 16384), EndOfTable(), MemoryDevice(sizeField: 32768));
+
+        Assert.That(CreateReader().Read().Modules, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Read_WhenTableHasNoMemoryDevices_ReturnsEmpty()
+    {
+        // A type 1 (System Information) structure, then the marker.
+        WriteTable([1, 4, 0x01, 0x00, 0x00, 0x00], EndOfTable());
+
+        Assert.That(CreateReader().Read().IsEmpty, Is.True);
+    }
+
+    [Test]
+    public void Read_WhenTableIsTruncatedMidStructure_DoesNotThrow()
+    {
+        WriteTable(MemoryDevice(sizeField: 16384)[..10]);
+
+        Assert.That(() => CreateReader().Read(), Throws.Nothing);
+    }
+
+    [TestCase((ushort)0, 0UL)]
+    [TestCase((ushort)0xFFFF, 0UL)]
+    [TestCase((ushort)1024, 1024UL * 1024 * 1024)]
+    public void ReadCapacityBytes_HandlesSentinelValues(ushort sizeField, ulong expected)
+        => Assert.That(LinuxDmiMemoryInventoryReader.ReadCapacityBytes(sizeField, 0), Is.EqualTo(expected));
+
+    [Test]
+    public void ReadString_WhenIndexIsZero_ReturnsNull()
+        => Assert.That(LinuxDmiMemoryInventoryReader.ReadString([0, 0], 0, 0), Is.Null);
+
+    [Test]
+    public void ReadString_WhenIndexIsPastTheTable_ReturnsNull()
+    {
+        var table = StringTable("first", "second");
+
+        Assert.That(LinuxDmiMemoryInventoryReader.ReadString(table, 0, 5), Is.Null);
+    }
+}


### PR DESCRIPTION
Closes #66.

> **Builds on #68 and #70.** Those commits appear in this diff until they merge; afterwards this reduces to the memory reader alone.

## Why

`Hardware.Info`'s Linux memory list is wrong in two separate ways. Running **as root** on a machine with exactly two SODIMMs, 32 GB + 16 GB:

```
MemoryList.Count = 3
--- Capacity=51539607552 (48 GiB)
  BankLabel=[] Manufacturer=[] PartNumber=[] Serial=[]
  Speed=0 FormFactor=UNKNOWN
--- Capacity=34359738368 (32 GiB)   Speed=2667 FormFactor=SODIMM
--- Capacity=17179869184 (16 GiB)   Speed=3200 FormFactor=SODIMM
```

The first entry is the other two added together — it parses `lshw` output and keeps the `System Memory` **container** node as though it were a module. `Speed=0` and `FormFactor=UNKNOWN` are the tell.

Separately, manufacturer, part number, serial number and bank label come back empty for every module, and memory type and data width are never reported at all.

In the UI this reads as three modules, the phantom labelled `Unknown` because it has no part number — which makes it look as though the real modules are missing data too.

## What this changes

`LinuxDmiMemoryInventoryReader` parses SMBIOS type 17 from `/sys/firmware/dmi/tables/DMI`. That table carries every field the UI wants, one structure per physical socket. SMBIOS has no aggregate node, so the phantom cannot occur; empty sockets are present but identified by a zero size and skipped.

The table is `0400 root`, which the service already satisfies. An unprivileged caller gets an empty inventory — no worse than today, since `Hardware.Info` also reports zero modules unprivileged.

Parsing is defensive in the same spirit as the EDID parser. Every field read is bounds-checked against the structure's **declared length** rather than the buffer, so an SMBIOS 2.1 structure that legitimately ends before the fields added in 2.3 and 2.7 reports those as unknown instead of reading a neighbouring structure's bytes. The walk stops at the end-of-table marker or the first malformed header.

The size field needs particular care and has a test per form: bit 15 is a kilobyte/megabyte selector, `0x7FFF` redirects to the extended 32-bit field, and `0xFFFF` means unknown. A 32 GB module cannot be expressed in the plain megabyte form at all and must use the extended field — my first fixture got this wrong and the parser correctly rejected it, which is why that case is now explicitly tested.

## Cross-platform

Gated at registration rather than by `#if`, matching the drive and graphics readers. Windows registers the null object and continues to use `Hardware.Info` unchanged. The constructor parameter is optional and defaults to the null object.

## One thing worth flagging for review

This makes memory **serial numbers** available where `Hardware.Info` previously returned them blank. They are exposed through the existing `HardwareInfoGrpcService`, which per `SECURITY.md` has no caller-identity validation in 0.1.0. That is a pre-existing posture rather than something this PR changes, but it does put real data behind a field that was previously empty, so it seemed worth naming rather than leaving for you to discover.

## Verification

- `dotnet test` — 324 passed, 0 failed (15 new)
- Both target frameworks build with zero warnings and zero errors
- Verified on real hardware: Framework 13, 13th Gen Intel, two SODIMMs — reports exactly two modules with type, speed, part number and serial populated, and no phantom entry

I have one machine and one memory configuration, so registered/ECC modules, populated-but-unknown-size slots and pre-2.7 firmware are covered by tests against synthetic SMBIOS tables rather than by real hardware.

---
Written with AI assistance; I have reviewed the change and stand behind it, per the AI Usage Notice in CONTRIBUTING.md.