### PR TITLE
feat: tell the user when a newer SubZero is released

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,6 +34,7 @@
          enumeration). Preferred over hand-written interop: the struct layouts and handle lifetimes are the
          part most likely to be subtly wrong, and these are maintained and MIT-licensed. -->
     <PackageVersion Include="ILGPU" Version="1.5.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
     <PackageVersion Include="Vanara.PInvoke.Msi" Version="5.0.5" />
     <PackageVersion Include="Vanara.PInvoke.Pdh" Version="5.0.5" />
     <PackageVersion Include="Vanara.PInvoke.SetupAPI" Version="5.0.5" />

--- a/SubZeroFramework.Core/Models/UpdateAvailability.cs
+++ b/SubZeroFramework.Core/Models/UpdateAvailability.cs
@@ -1,0 +1,57 @@
+namespace SubZeroFramework.Models;
+
+/// <summary>How an update check ended.</summary>
+public enum UpdateCheckStatus
+{
+    /// <summary>
+    /// The question could not be answered — offline, rate-limited, no releases published, or the running
+    /// version could not be determined (a local dev build stamps none).
+    /// </summary>
+    /// <remarks>
+    /// Distinct from <see cref="UpToDate"/> on purpose. Collapsing the two told a user whose check had
+    /// FAILED that they were on the newest release, which is a claim the app had no evidence for.
+    /// </remarks>
+    Unknown,
+
+    /// <summary>The feed was read and nothing newer than the running version exists.</summary>
+    UpToDate,
+
+    /// <summary>A strictly newer release exists.</summary>
+    UpdateAvailable,
+}
+
+/// <summary>
+/// The outcome of one update check.
+/// </summary>
+/// <remarks>
+/// <see cref="None"/> is the answer to every failure — offline, rate-limited, no releases published, a tag
+/// that could not be parsed. The caller cannot tell those apart on purpose: none of them is something to
+/// show a user who did not ask, and collapsing them here keeps that decision out of the UI.
+/// </remarks>
+public sealed record UpdateAvailability
+{
+    /// <summary>Nothing to offer, for any reason.</summary>
+    public static UpdateAvailability None { get; } = new();
+
+    /// <summary>The newest published release, or null when none could be resolved.</summary>
+    public Version? LatestVersion { get; init; }
+
+    /// <summary>
+    /// The version currently running, so the UI can state both sides of the comparison.
+    /// </summary>
+    /// <remarks>
+    /// Carried here rather than re-derived in the view: "0.1.6 is available" is a fact the user cannot act
+    /// on without knowing what they are on, and having the UI parse the assembly a second time would put a
+    /// second copy of the version rules where the first one could drift away from it.
+    /// </remarks>
+    public Version? CurrentVersion { get; init; }
+
+    /// <summary>The release's own page on GitHub, or null. Already validated as a github.com URL.</summary>
+    public string? ReleaseUrl { get; init; }
+
+    /// <summary>How the check ended, so the UI can tell "nothing newer" from "could not ask".</summary>
+    public UpdateCheckStatus Status { get; init; } = UpdateCheckStatus.Unknown;
+
+    /// <summary>True only when a strictly newer version was resolved AND has somewhere to send the user.</summary>
+    public bool IsUpdateAvailable => LatestVersion is not null && !string.IsNullOrWhiteSpace(ReleaseUrl);
+}

--- a/SubZeroFramework.Core/Services/Updates/AppVersion.cs
+++ b/SubZeroFramework.Core/Services/Updates/AppVersion.cs
@@ -1,0 +1,69 @@
+namespace SubZeroFramework.Services.Updates;
+
+/// <summary>
+/// Parses and compares the two version strings the update check has to reconcile: the app's own
+/// <c>AssemblyInformationalVersion</c> and a GitHub release tag.
+/// </summary>
+/// <remarks>
+/// In Core rather than beside the UI that shows the result, because this is where the tests can reach it:
+/// the cross-platform test project references Core and the service, never the Uno app head.
+/// </remarks>
+public static class AppVersion
+{
+    /// <summary>The version in <paramref name="raw"/>, or null when it is not one this can compare safely.</summary>
+    /// <param name="raw">A release tag ("v0.1.6") or an informational version ("0.1.5+abc1234").</param>
+    /// <returns>The parsed version, or null.</returns>
+    /// <remarks>
+    /// Refusing is the safe answer, not a fallback: a string this cannot parse — a prerelease tag, a moving
+    /// "nightly" tag, a hand-cut label — must produce silence rather than a guess, because the only thing the
+    /// result drives is whether to tell the user their install is out of date.
+    /// </remarks>
+    public static Version? Parse(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var text = raw.Trim();
+
+        // SourceLink appends "+<commit-hash>" to the informational version.
+        var plusIndex = text.IndexOf('+', StringComparison.Ordinal);
+        if (plusIndex > 0)
+        {
+            text = text[..plusIndex];
+        }
+
+        if (text.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+        {
+            text = text[1..];
+        }
+
+        // Version.TryParse is culture-invariant by definition (digits and dots only), so there is no
+        // IFormatProvider overload to pass one to.
+        return Version.TryParse(text, out var version) ? version : null;
+    }
+
+    /// <summary>True when <paramref name="candidate"/> is strictly ahead of <paramref name="current"/>.</summary>
+    /// <param name="candidate">The version offered by the release feed.</param>
+    /// <param name="current">The running version.</param>
+    /// <returns>True when an update is genuinely available.</returns>
+    /// <remarks>
+    /// Both sides are normalised to four fields first. A tag is cut as "v0.1.6" while a local build stamps
+    /// "0.1.6.0"; comparing them raw makes the same release look newer than itself, and the tip would then
+    /// appear on every launch of an install that is already current.
+    /// </remarks>
+    public static bool IsNewer(Version candidate, Version current)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(current);
+
+        return Normalize(candidate) > Normalize(current);
+    }
+
+    private static Version Normalize(Version version) => new(
+        version.Major,
+        version.Minor,
+        version.Build < 0 ? 0 : version.Build,
+        version.Revision < 0 ? 0 : version.Revision);
+}

--- a/SubZeroFramework.Core/Services/Updates/IUpdateCheckClient.cs
+++ b/SubZeroFramework.Core/Services/Updates/IUpdateCheckClient.cs
@@ -1,0 +1,143 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Microsoft.Extensions.Logging;
+
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Updates;
+
+/// <summary>One fetch of the release feed: what it found, its ETag, and whether it was unchanged.</summary>
+/// <param name="Availability">What to offer the user, or <see cref="UpdateAvailability.None"/>.</param>
+/// <param name="ETag">The response ETag, to send back next time. Null when there was none.</param>
+/// <param name="NotModified">True when the server answered 304 and the caller should reuse its cache.</param>
+public sealed record UpdateCheckResult(UpdateAvailability Availability, string? ETag, bool NotModified);
+
+/// <summary>Asks somewhere whether a newer release exists.</summary>
+public interface IUpdateCheckClient
+{
+    /// <summary>Fetches the latest release, sending <paramref name="etag"/> if one is known.</summary>
+    /// <param name="etag">The ETag from the previous fetch, or null.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The result; never throws.</returns>
+    Task<UpdateCheckResult> FetchLatestAsync(string? etag, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Reads the latest published release from the GitHub API.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>/releases/latest</c> rather than <c>/releases</c>: it already excludes drafts and prereleases, which
+/// matches what CI can produce — <c>build.yml</c> refuses a tag containing '-'.
+/// </para>
+/// <para>
+/// NOTHING here throws. Every failure — no network, a 403 from the unauthenticated 60/hour limit shared
+/// across a NAT, a repo with no releases, a body that changed shape — returns
+/// <see cref="UpdateAvailability.None"/>. The check is unsolicited, so a failure the user did not ask for
+/// must be invisible.
+/// </para>
+/// </remarks>
+public sealed class GitHubUpdateCheckClient : IUpdateCheckClient
+{
+    private const string LatestReleaseUrl = "https://api.github.com/repos/TekuSP/SubZeroFramework/releases/latest";
+
+    /// <summary>The only host and path prefix a release URL may have.</summary>
+    private const string ReleaseUrlPrefix = "https://github.com/TekuSP/SubZeroFramework/";
+
+    private static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(10);
+
+    private readonly HttpClient _client;
+    private readonly ILogger<GitHubUpdateCheckClient> _logger;
+
+    /// <summary>Creates the client.</summary>
+    /// <param name="client">The HTTP client to send with.</param>
+    /// <param name="logger">Where failures are recorded, since none of them reach the user.</param>
+    public GitHubUpdateCheckClient(HttpClient client, ILogger<GitHubUpdateCheckClient> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<UpdateCheckResult> FetchLatestAsync(string? etag, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
+
+            // Mandatory: GitHub answers 403 to a request without one.
+            request.Headers.UserAgent.Add(new ProductInfoHeaderValue("SubZeroFramework", "1.0"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+            if (!string.IsNullOrWhiteSpace(etag))
+            {
+                request.Headers.TryAddWithoutValidation("If-None-Match", etag);
+            }
+
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeout.CancelAfter(RequestTimeout);
+
+            using var response = await _client.SendAsync(request, timeout.Token).ConfigureAwait(false);
+
+            // Unchanged since last time, and it cost no rate-limit quota.
+            if (response.StatusCode == HttpStatusCode.NotModified)
+            {
+                return new UpdateCheckResult(UpdateAvailability.None, etag, NotModified: true);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("The update check returned {StatusCode}; leaving the cached result alone.", response.StatusCode);
+                return new UpdateCheckResult(UpdateAvailability.None, etag, NotModified: false);
+            }
+
+            var body = await response.Content.ReadAsStringAsync(timeout.Token).ConfigureAwait(false);
+            var release = JsonSerializer.Deserialize(body, GitHubReleaseJsonContext.Default.GitHubRelease);
+            var responseETag = response.Headers.ETag?.ToString() ?? etag;
+
+            if (AppVersion.Parse(release?.TagName) is not { } version || !IsTrustedReleaseUrl(release?.HtmlUrl))
+            {
+                _logger.LogDebug("The update check found no usable release (tag '{Tag}').", release?.TagName);
+                return new UpdateCheckResult(UpdateAvailability.None, responseETag, NotModified: false);
+            }
+
+            return new UpdateCheckResult(
+                new UpdateAvailability { LatestVersion = version, ReleaseUrl = release!.HtmlUrl },
+                responseETag,
+                NotModified: false);
+        }
+        catch (Exception exception) when (exception is HttpRequestException or TaskCanceledException or JsonException or InvalidOperationException)
+        {
+            _logger.LogDebug(exception, "The update check could not complete.");
+            return new UpdateCheckResult(UpdateAvailability.None, etag, NotModified: false);
+        }
+    }
+
+    /// <summary>Whether a URL from the response may be handed to the shell.</summary>
+    /// <remarks>
+    /// The URL arrives over the network, and the app will LAUNCH it. Anything that is not this repo's own
+    /// HTTPS release area is refused rather than opened.
+    /// </remarks>
+    private static bool IsTrustedReleaseUrl(string? url)
+        => !string.IsNullOrWhiteSpace(url)
+            && url.StartsWith(ReleaseUrlPrefix, StringComparison.Ordinal);
+}
+
+/// <summary>The two fields this needs from the release payload.</summary>
+internal sealed record GitHubRelease
+{
+    /// <summary>The release tag, e.g. "v0.1.6".</summary>
+    [JsonPropertyName("tag_name")]
+    public string? TagName { get; init; }
+
+    /// <summary>The release's page on github.com.</summary>
+    [JsonPropertyName("html_url")]
+    public string? HtmlUrl { get; init; }
+}
+
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(GitHubRelease))]
+internal sealed partial class GitHubReleaseJsonContext : JsonSerializerContext;

--- a/SubZeroFramework.Core/Services/Updates/UpdateCheckState.cs
+++ b/SubZeroFramework.Core/Services/Updates/UpdateCheckState.cs
@@ -1,0 +1,32 @@
+namespace SubZeroFramework.Services.Updates;
+
+/// <summary>What the last update check found, so a launch can act without going to the network.</summary>
+public sealed record UpdateCheckState
+{
+    /// <summary>When the feed was last successfully contacted.</summary>
+    public DateTimeOffset? LastCheckedUtc { get; init; }
+
+    /// <summary>The ETag to revalidate with, so an unchanged feed costs no rate-limit quota.</summary>
+    public string? ETag { get; init; }
+
+    /// <summary>The newest version seen, as a string so the file stays readable.</summary>
+    public string? LatestVersion { get; init; }
+
+    /// <summary>That release's page.</summary>
+    public string? LatestReleaseUrl { get; init; }
+}
+
+/// <summary>Persistence for <see cref="UpdateCheckState"/>.</summary>
+/// <remarks>
+/// The interface lives in Core so the coordinator can be tested against a fake; the implementation that
+/// writes to the per-user application-data folder lives in the app, beside the other client-only stores.
+/// </remarks>
+public interface IUpdateCheckStateStore
+{
+    /// <summary>The state as last read or written.</summary>
+    UpdateCheckState Current { get; }
+
+    /// <summary>Replaces the state and writes it to disk.</summary>
+    /// <param name="state">The new state.</param>
+    void Save(UpdateCheckState state);
+}

--- a/SubZeroFramework.Core/Services/Updates/UpdateNotificationCoordinator.cs
+++ b/SubZeroFramework.Core/Services/Updates/UpdateNotificationCoordinator.cs
@@ -1,0 +1,150 @@
+using Microsoft.Extensions.Logging;
+
+using SubZeroFramework.Models;
+
+namespace SubZeroFramework.Services.Updates;
+
+/// <summary>Decides whether there is an update worth telling the user about.</summary>
+public interface IUpdateNotificationCoordinator
+{
+    /// <summary>Returns what to offer, contacting the feed only when it is due.</summary>
+    /// <param name="force">True for a user-initiated check, which ignores the interval and the opt-out.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>What to offer, or <see cref="UpdateAvailability.None"/>.</returns>
+    Task<UpdateAvailability> EvaluateAsync(bool force, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Rate-limits the network check, caches its verdict, and applies it to the running version.
+/// </summary>
+/// <remarks>
+/// The interval governs the FETCH, never the answer: the tip is meant to appear on every launch while an
+/// update is outstanding, so a launch inside the window still gets the cached verdict — which also means the
+/// tip works offline once the release has been seen once.
+/// </remarks>
+public sealed class UpdateNotificationCoordinator : IUpdateNotificationCoordinator
+{
+    /// <summary>How long a fetched verdict is reused before the feed is contacted again.</summary>
+    /// <remarks>
+    /// The unauthenticated API allows 60 requests an hour per IP, shared across everyone behind a NAT.
+    /// Once a day per install leaves that budget alone even on a busy network.
+    /// </remarks>
+    public static readonly TimeSpan CheckInterval = TimeSpan.FromHours(24);
+
+    private readonly IUpdateCheckClient _client;
+    private readonly IUpdateCheckStateStore _stateStore;
+    private readonly Func<bool> _areAutomaticChecksEnabled;
+    private readonly Version? _currentVersion;
+    private readonly Func<DateTimeOffset> _clock;
+    private readonly ILogger<UpdateNotificationCoordinator> _logger;
+
+    /// <summary>Creates the coordinator.</summary>
+    /// <param name="client">The release feed.</param>
+    /// <param name="stateStore">Where the cached verdict lives.</param>
+    /// <param name="areAutomaticChecksEnabled">
+    /// Reads the user's opt-out. A delegate rather than the settings store itself, so Core does not have to
+    /// know about the app's settings surface — and so a user toggling it mid-session is seen immediately.
+    /// </param>
+    /// <param name="currentVersion">The running version, or null when it could not be parsed.</param>
+    /// <param name="clock">The clock, injected so the interval is testable without waiting a day.</param>
+    /// <param name="logger">Where failures are recorded.</param>
+    public UpdateNotificationCoordinator(
+        IUpdateCheckClient client,
+        IUpdateCheckStateStore stateStore,
+        Func<bool> areAutomaticChecksEnabled,
+        Version? currentVersion,
+        Func<DateTimeOffset> clock,
+        ILogger<UpdateNotificationCoordinator> logger)
+    {
+        _client = client;
+        _stateStore = stateStore;
+        _areAutomaticChecksEnabled = areAutomaticChecksEnabled;
+        _currentVersion = currentVersion;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<UpdateAvailability> EvaluateAsync(bool force, CancellationToken cancellationToken)
+    {
+        if (!force && !_areAutomaticChecksEnabled())
+        {
+            return UpdateAvailability.None;
+        }
+
+        // No usable local version — a dev build, or something unparseable. Comparing against it would be
+        // guessing, and the only thing the answer drives is telling the user their install is stale.
+        if (_currentVersion is null)
+        {
+            return UpdateAvailability.None;
+        }
+
+        var state = _stateStore.Current;
+
+        if (force || IsDue(state))
+        {
+            state = await FetchAsync(state, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Nothing cached and nothing fetched: the feed was never successfully read, so "up to date" would be
+        // a claim with no evidence behind it. Unknown is the honest answer.
+        if (state.LastCheckedUtc is null || string.IsNullOrWhiteSpace(state.LatestVersion))
+        {
+            return new UpdateAvailability { CurrentVersion = _currentVersion, Status = UpdateCheckStatus.Unknown };
+        }
+
+        if (AppVersion.Parse(state.LatestVersion) is not { } latest
+            || string.IsNullOrWhiteSpace(state.LatestReleaseUrl)
+            || !AppVersion.IsNewer(latest, _currentVersion))
+        {
+            // Nothing to offer, but the running version is still worth carrying: a user who PRESSED a check
+            // button is owed "SubZero 0.1.5 is the newest release", not a bare "nothing found".
+            return new UpdateAvailability { CurrentVersion = _currentVersion, Status = UpdateCheckStatus.UpToDate };
+        }
+
+        // CurrentVersion is filled in HERE, not by the client: the client knows what GitHub published, the
+        // coordinator is the only thing that also knows what is running.
+        return new UpdateAvailability
+        {
+            LatestVersion = latest,
+            CurrentVersion = _currentVersion,
+            ReleaseUrl = state.LatestReleaseUrl,
+            Status = UpdateCheckStatus.UpdateAvailable,
+        };
+    }
+
+    private bool IsDue(UpdateCheckState state)
+        => state.LastCheckedUtc is not { } lastChecked || _clock() - lastChecked >= CheckInterval;
+
+    private async Task<UpdateCheckState> FetchAsync(UpdateCheckState state, CancellationToken cancellationToken)
+    {
+        var result = await _client.FetchLatestAsync(state.ETag, cancellationToken).ConfigureAwait(false);
+
+        // 304: the feed is unchanged, so the cached version and URL stand. Only the timestamp moves.
+        if (result.NotModified)
+        {
+            var revalidated = state with { LastCheckedUtc = _clock(), ETag = result.ETag ?? state.ETag };
+            _stateStore.Save(revalidated);
+            return revalidated;
+        }
+
+        // A failed fetch must not erase a good cached verdict — otherwise going offline hides an update the
+        // user has already been told about.
+        if (!result.Availability.IsUpdateAvailable)
+        {
+            _logger.LogDebug("The update check found nothing new; the cached verdict stands.");
+            return state;
+        }
+
+        var updated = state with
+        {
+            LastCheckedUtc = _clock(),
+            ETag = result.ETag,
+            LatestVersion = result.Availability.LatestVersion?.ToString(),
+            LatestReleaseUrl = result.Availability.ReleaseUrl,
+        };
+
+        _stateStore.Save(updated);
+        return updated;
+    }
+}

--- a/SubZeroFramework.Tests/AppVersionTests.cs
+++ b/SubZeroFramework.Tests/AppVersionTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+
+using SubZeroFramework.Services.Updates;
+
+namespace SubZeroFramework.Tests;
+
+/// <summary>
+/// Cover for the two version strings this app has to reconcile: its own informational version and a
+/// GitHub release tag.
+/// </summary>
+[TestFixture]
+public class AppVersionTests
+{
+    [TestCase("v0.1.6", "0.1.6")]
+    [TestCase("0.1.6", "0.1.6")]
+    [TestCase("V0.1.6", "0.1.6")]
+    [TestCase("0.1.5.0", "0.1.5.0")]
+    [TestCase("0.1.5+abc1234", "0.1.5")]
+    public void Parse_AcceptsTheFormsBothSidesActuallyProduce(string raw, string expected)
+        => Assert.That(AppVersion.Parse(raw), Is.EqualTo(Version.Parse(expected)));
+
+    // A tag CI would never cut (build.yml rejects '-'), and anything that is not a version at all.
+    [TestCase("v0.1.6-beta")]
+    [TestCase("nightly")]
+    [TestCase("")]
+    [TestCase(null)]
+    public void Parse_RefusesAnythingItCannotCompareSafely(string? raw)
+        => Assert.That(AppVersion.Parse(raw), Is.Null);
+
+    [Test]
+    public void IsNewer_IsTrue_OnlyWhenTheCandidateIsStrictlyAhead()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(AppVersion.IsNewer(Version.Parse("0.1.6"), Version.Parse("0.1.5")), Is.True);
+            Assert.That(AppVersion.IsNewer(Version.Parse("0.2.0"), Version.Parse("0.1.9")), Is.True);
+            Assert.That(AppVersion.IsNewer(Version.Parse("0.1.5"), Version.Parse("0.1.5")), Is.False, "equal is not an update");
+            Assert.That(AppVersion.IsNewer(Version.Parse("0.1.4"), Version.Parse("0.1.5")), Is.False, "older must never prompt");
+        });
+    }
+
+    // 0.1.6 and 0.1.6.0 are the same release stamped two ways: the tag omits the fourth field, a local
+    // build carries it. Treating them as different would prompt forever on the version already installed.
+    [Test]
+    public void IsNewer_TreatsAnOmittedFourthField_AsEqual()
+        => Assert.That(AppVersion.IsNewer(Version.Parse("0.1.6"), Version.Parse("0.1.6.0")), Is.False);
+}

--- a/SubZeroFramework.Tests/GitHubUpdateCheckClientTests.cs
+++ b/SubZeroFramework.Tests/GitHubUpdateCheckClientTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Text;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NUnit.Framework;
+
+using SubZeroFramework.Services.Updates;
+
+namespace SubZeroFramework.Tests;
+
+/// <summary>
+/// Cover for the release-feed client, whose whole contract is "answer something useful or answer nothing,
+/// but never throw and never surface an error".
+/// </summary>
+[TestFixture]
+public class GitHubUpdateCheckClientTests
+{
+    private const string LatestReleaseJson = """
+        {
+          "tag_name": "v0.1.6",
+          "html_url": "https://github.com/TekuSP/SubZeroFramework/releases/tag/v0.1.6"
+        }
+        """;
+
+    [Test]
+    public async Task FetchLatestAsync_ReturnsTheTagAndUrl_OnSuccess()
+    {
+        var client = Client(new StubHandler(HttpStatusCode.OK, LatestReleaseJson, etag: "\"abc\""));
+
+        var result = await client.FetchLatestAsync(etag: null, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Availability.LatestVersion, Is.EqualTo(Version.Parse("0.1.6")));
+            Assert.That(result.Availability.ReleaseUrl, Is.EqualTo("https://github.com/TekuSP/SubZeroFramework/releases/tag/v0.1.6"));
+            Assert.That(result.ETag, Is.EqualTo("\"abc\""));
+            Assert.That(result.NotModified, Is.False);
+        });
+    }
+
+    [Test]
+    public async Task FetchLatestAsync_SendsAUserAgent_BecauseGitHubRefusesWithoutOne()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK, LatestReleaseJson);
+        var client = Client(handler);
+
+        await client.FetchLatestAsync(etag: null, CancellationToken.None);
+
+        Assert.That(handler.LastRequest!.Headers.UserAgent, Is.Not.Empty);
+    }
+
+    [Test]
+    public async Task FetchLatestAsync_SendsIfNoneMatch_WhenAnETagIsKnown()
+    {
+        var handler = new StubHandler(HttpStatusCode.NotModified, body: null);
+        var client = Client(handler);
+
+        var result = await client.FetchLatestAsync("\"abc\"", CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(handler.LastRequest!.Headers.IfNoneMatch.ToString(), Is.EqualTo("\"abc\""));
+            Assert.That(result.NotModified, Is.True, "304 must be reported so the cached verdict is reused");
+        });
+    }
+
+    // Every one of these is a normal condition, not an error: no network, a shared IP that burned the
+    // 60/hour limit, a repo with no releases yet, a body that is not what we expected.
+    [TestCase(HttpStatusCode.Forbidden, null)]
+    [TestCase(HttpStatusCode.NotFound, null)]
+    [TestCase(HttpStatusCode.OK, "{ \"tag_name\": \"nightly\" }")]
+    [TestCase(HttpStatusCode.OK, "not json at all")]
+    public async Task FetchLatestAsync_ReturnsNone_AndNeverThrows(HttpStatusCode status, string? body)
+    {
+        var client = Client(new StubHandler(status, body));
+
+        var result = await client.FetchLatestAsync(etag: null, CancellationToken.None);
+
+        Assert.That(result.Availability.IsUpdateAvailable, Is.False);
+    }
+
+    [Test]
+    public async Task FetchLatestAsync_ReturnsNone_WhenTheTransportFails()
+    {
+        var client = Client(new ThrowingHandler());
+
+        var result = await client.FetchLatestAsync(etag: null, CancellationToken.None);
+
+        Assert.That(result.Availability.IsUpdateAvailable, Is.False);
+    }
+
+    // A release URL is a string from the network, and the app will LAUNCH it. Anything not on this repo
+    // over HTTPS is refused rather than handed to the shell.
+    [TestCase("https://evil.example.com/releases/tag/v0.1.6")]
+    [TestCase("http://github.com/TekuSP/SubZeroFramework/releases/tag/v0.1.6")]
+    [TestCase("https://github.com/someone-else/SubZeroFramework/releases/tag/v0.1.6")]
+    public async Task FetchLatestAsync_RefusesAReleaseUrl_ThatIsNotOnThisRepoOverHttps(string url)
+    {
+        var json = $$"""{ "tag_name": "v0.1.6", "html_url": "{{url}}" }""";
+        var client = Client(new StubHandler(HttpStatusCode.OK, json));
+
+        var result = await client.FetchLatestAsync(etag: null, CancellationToken.None);
+
+        Assert.That(result.Availability.IsUpdateAvailable, Is.False);
+    }
+
+    private HttpClient? _http;
+
+    /// <summary>The client under test owns no disposable state; the HttpClient behind it does.</summary>
+    [TearDown]
+    public void DisposeHttpClient()
+    {
+        _http?.Dispose();
+        _http = null;
+    }
+
+    private GitHubUpdateCheckClient Client(HttpMessageHandler handler)
+    {
+        _http = new HttpClient(handler);
+        return new GitHubUpdateCheckClient(_http, NullLogger<GitHubUpdateCheckClient>.Instance);
+    }
+
+    private sealed class StubHandler(HttpStatusCode status, string? body, string? etag = null) : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            var response = new HttpResponseMessage(status);
+
+            if (body is not null)
+            {
+                response.Content = new StringContent(body, Encoding.UTF8, "application/json");
+            }
+
+            if (etag is not null)
+            {
+                response.Headers.TryAddWithoutValidation("ETag", etag);
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => throw new HttpRequestException("no network");
+    }
+}

--- a/SubZeroFramework.Tests/UpdateNotificationCoordinatorTests.cs
+++ b/SubZeroFramework.Tests/UpdateNotificationCoordinatorTests.cs
@@ -1,0 +1,268 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+using NUnit.Framework;
+
+using SubZeroFramework.Models;
+using SubZeroFramework.Services.Updates;
+
+namespace SubZeroFramework.Tests;
+
+/// <summary>
+/// Cover for the rule the update notification actually runs on: rate-limit the FETCH, never the answer.
+/// </summary>
+[TestFixture]
+public class UpdateNotificationCoordinatorTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 27, 12, 0, 0, TimeSpan.Zero);
+    private const string ReleaseUrl = "https://github.com/TekuSP/SubZeroFramework/releases/tag/v0.1.6";
+
+    [Test]
+    public async Task EvaluateAsync_OffersTheUpdate_WhenTheFeedIsAhead()
+    {
+        var client = new StubClient(Availability("0.1.6"));
+        var coordinator = Coordinator(client, current: "0.1.5");
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.That(availability.IsUpdateAvailable, Is.True);
+    }
+
+    // The tip states both sides ("0.1.6 is available — you're on 0.1.5"), so the result has to carry both.
+    [Test]
+    public async Task EvaluateAsync_CarriesBothVersions_SoTheTipCanStateTheComparison()
+    {
+        var coordinator = Coordinator(new StubClient(Availability("0.1.6")), current: "0.1.5");
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(availability.LatestVersion, Is.EqualTo(Version.Parse("0.1.6")));
+            Assert.That(availability.CurrentVersion, Is.EqualTo(Version.Parse("0.1.5")));
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_OffersNothing_WhenTheFeedMatchesTheRunningVersion()
+    {
+        var coordinator = Coordinator(new StubClient(Availability("0.1.5")), current: "0.1.5");
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.That(availability.IsUpdateAvailable, Is.False);
+    }
+
+    // Someone who pressed a check button is owed "0.1.5 is the newest release", not a bare "nothing found".
+    [Test]
+    public async Task EvaluateAsync_StillReportsTheRunningVersion_WhenThereIsNoUpdate()
+    {
+        var coordinator = Coordinator(new StubClient(Availability("0.1.5")), current: "0.1.5");
+
+        var availability = await coordinator.EvaluateAsync(force: true, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(availability.IsUpdateAvailable, Is.False);
+            Assert.That(availability.CurrentVersion, Is.EqualTo(Version.Parse("0.1.5")));
+            Assert.That(availability.Status, Is.EqualTo(UpdateCheckStatus.UpToDate));
+        });
+    }
+
+    // "Up to date" is a CLAIM. A check that never reached the feed has no evidence for it, and saying it
+    // anyway tells a user on an old build that they are current.
+    [Test]
+    public async Task EvaluateAsync_ReportsUnknown_NotUpToDate_WhenTheFeedWasNeverRead()
+    {
+        var coordinator = Coordinator(new StubClient(UpdateAvailability.None), current: "0.1.5");
+
+        var availability = await coordinator.EvaluateAsync(force: true, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(availability.IsUpdateAvailable, Is.False);
+            Assert.That(availability.Status, Is.EqualTo(UpdateCheckStatus.Unknown), "a failed fetch must not read as 'up to date'");
+        });
+    }
+
+    // A local Debug build stamps no version attributes at all, so there is nothing to compare against.
+    [Test]
+    public async Task EvaluateAsync_ReportsUnknown_WhenTheRunningVersionCannotBeDetermined()
+    {
+        var coordinator = Coordinator(new StubClient(Availability("0.1.6")), current: null);
+
+        var availability = await coordinator.EvaluateAsync(force: true, CancellationToken.None);
+
+        Assert.That(availability.Status, Is.EqualTo(UpdateCheckStatus.Unknown));
+    }
+
+    [Test]
+    public async Task EvaluateAsync_ReportsUpdateAvailable_WhenTheFeedIsAhead()
+    {
+        var coordinator = Coordinator(new StubClient(Availability("0.1.6")), current: "0.1.5");
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.That(availability.Status, Is.EqualTo(UpdateCheckStatus.UpdateAvailable));
+    }
+
+    // The check is rate-limited; the TIP is not. A launch inside the window must still be able to offer the
+    // update, from cache, without touching the network.
+    [Test]
+    public async Task EvaluateAsync_UsesTheCache_WithoutCallingTheFeed_InsideTheInterval()
+    {
+        var stateStore = new StubStateStore(new UpdateCheckState
+        {
+            LastCheckedUtc = Now.AddHours(-1),
+            LatestVersion = "0.1.6",
+            LatestReleaseUrl = ReleaseUrl,
+        });
+        var client = new StubClient(UpdateAvailability.None);
+        var coordinator = Coordinator(client, current: "0.1.5", stateStore: stateStore);
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.Calls, Is.Zero, "the feed was contacted inside the 24 h interval");
+            Assert.That(availability.IsUpdateAvailable, Is.True, "the cached result must still raise the tip");
+        });
+    }
+
+    [Test]
+    public async Task EvaluateAsync_ContactsTheFeed_OnceTheIntervalHasElapsed()
+    {
+        var stateStore = new StubStateStore(new UpdateCheckState { LastCheckedUtc = Now.AddHours(-25) });
+        var client = new StubClient(Availability("0.1.6"));
+        var coordinator = Coordinator(client, current: "0.1.5", stateStore: stateStore);
+
+        await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.That(client.Calls, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task EvaluateAsync_ContactsTheFeed_WhenForced_EvenInsideTheInterval()
+    {
+        var stateStore = new StubStateStore(new UpdateCheckState { LastCheckedUtc = Now });
+        var client = new StubClient(Availability("0.1.6"));
+        var coordinator = Coordinator(client, current: "0.1.5", stateStore: stateStore);
+
+        await coordinator.EvaluateAsync(force: true, CancellationToken.None);
+
+        Assert.That(client.Calls, Is.EqualTo(1), "a user-initiated check must bypass the interval");
+    }
+
+    [Test]
+    public async Task EvaluateAsync_DoesNothing_WhenTheUserTurnedChecksOff()
+    {
+        var client = new StubClient(Availability("0.1.6"));
+        var coordinator = Coordinator(client, current: "0.1.5", checksEnabled: false);
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.Calls, Is.Zero);
+            Assert.That(availability.IsUpdateAvailable, Is.False);
+        });
+    }
+
+    // Pressing the button IS asking, so the opt-out does not apply to it — it silences the automatic
+    // check, not the one the user just requested.
+    [Test]
+    public async Task EvaluateAsync_StillChecks_WhenForced_EvenWithChecksTurnedOff()
+    {
+        var client = new StubClient(Availability("0.1.6"));
+        var coordinator = Coordinator(client, current: "0.1.5", checksEnabled: false);
+
+        var availability = await coordinator.EvaluateAsync(force: true, CancellationToken.None);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(client.Calls, Is.EqualTo(1));
+            Assert.That(availability.IsUpdateAvailable, Is.True);
+        });
+    }
+
+    // A local build stamps 0.1.5.0 from Directory.Build.props while CI stamps 0.1.<run-number>, so a
+    // checkout can look older than a release it already contains.
+    [Test]
+    public async Task EvaluateAsync_OffersNothing_WhenTheRunningVersionIsUnknown()
+    {
+        var client = new StubClient(Availability("0.1.6"));
+        var coordinator = Coordinator(client, current: null);
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.That(availability.IsUpdateAvailable, Is.False);
+    }
+
+    [Test]
+    public async Task EvaluateAsync_KeepsTheCachedVerdict_WhenTheFeedAnswersNotModified()
+    {
+        var stateStore = new StubStateStore(new UpdateCheckState
+        {
+            LastCheckedUtc = Now.AddHours(-25),
+            ETag = "\"abc\"",
+            LatestVersion = "0.1.6",
+            LatestReleaseUrl = ReleaseUrl,
+        });
+        var client = new StubClient(UpdateAvailability.None, notModified: true, etag: "\"abc\"");
+        var coordinator = Coordinator(client, current: "0.1.5", stateStore: stateStore);
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.That(availability.IsUpdateAvailable, Is.True, "304 means unchanged, not 'no update'");
+    }
+
+    // Going offline must not hide an update the user has already been told about.
+    [Test]
+    public async Task EvaluateAsync_KeepsTheCachedVerdict_WhenTheFetchFails()
+    {
+        var stateStore = new StubStateStore(new UpdateCheckState
+        {
+            LastCheckedUtc = Now.AddHours(-25),
+            LatestVersion = "0.1.6",
+            LatestReleaseUrl = ReleaseUrl,
+        });
+        var coordinator = Coordinator(new StubClient(UpdateAvailability.None), current: "0.1.5", stateStore: stateStore);
+
+        var availability = await coordinator.EvaluateAsync(force: false, CancellationToken.None);
+
+        Assert.That(availability.IsUpdateAvailable, Is.True);
+    }
+
+    private static UpdateAvailability Availability(string version)
+        => new() { LatestVersion = Version.Parse(version), ReleaseUrl = ReleaseUrl };
+
+    private static UpdateNotificationCoordinator Coordinator(
+        StubClient client,
+        string? current,
+        StubStateStore? stateStore = null,
+        bool checksEnabled = true)
+        => new(
+            client,
+            stateStore ?? new StubStateStore(new UpdateCheckState()),
+            () => checksEnabled,
+            current is null ? null : Version.Parse(current),
+            () => Now,
+            NullLogger<UpdateNotificationCoordinator>.Instance);
+
+    private sealed class StubClient(UpdateAvailability availability, bool notModified = false, string? etag = null) : IUpdateCheckClient
+    {
+        public int Calls { get; private set; }
+
+        public Task<UpdateCheckResult> FetchLatestAsync(string? requestETag, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.FromResult(new UpdateCheckResult(availability, etag, notModified));
+        }
+    }
+
+    private sealed class StubStateStore(UpdateCheckState state) : IUpdateCheckStateStore
+    {
+        public UpdateCheckState Current { get; private set; } = state;
+
+        public void Save(UpdateCheckState next) => Current = next;
+    }
+}

--- a/SubZeroFramework/App.xaml
+++ b/SubZeroFramework/App.xaml
@@ -118,6 +118,7 @@
             <x:String x:Key="DeviceCapabilitiesMenuIcon">&#xE950;</x:String>
             <x:String x:Key="ModulesMenuIcon">ExpansionCardVariant</x:String>
             <x:String x:Key="WarningsMenuIcon">&#xE814;</x:String>
+            <x:String x:Key="UpdateMenuIcon">&#xE777;</x:String>
             <x:String x:Key="GithubMenuIcon">Github</x:String>
             <x:String x:Key="SettingsMenuIcon">&#xE713;</x:String>
 

--- a/SubZeroFramework/App.xaml.cs
+++ b/SubZeroFramework/App.xaml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Windowing;
@@ -181,6 +182,46 @@ public partial class App : Application
 
                     // Client-only settings: launch behavior + alert opt-ins persist next to the display units.
                     services.AddSingleton<ILocalClientSettingsStore, LocalClientSettingsStore>();
+
+                    // Update notification. The cached verdict lives beside the other client-only state; the
+                    // HTTP client goes through the factory because it owns handler lifetime, and a
+                    // long-running app holding one socket handler would pin a stale DNS entry all session.
+                    services.AddSingleton<SubZeroFramework.Services.Updates.IUpdateCheckStateStore, UpdateCheckStateStore>();
+
+#if DEBUG
+                    // --fake-latest short-circuits the network so the notice can be reached without a
+                    // published release. Compiled out of RELEASE entirely; see DebugUpdateOverrides.
+                    if (DebugUpdateOverrides.HasFakeLatest)
+                    {
+                        services.AddSingleton<SubZeroFramework.Services.Updates.IUpdateCheckClient, DebugUpdateOverrides.FakeClient>();
+                    }
+                    else
+                    {
+                        services.AddHttpClient<SubZeroFramework.Services.Updates.IUpdateCheckClient, SubZeroFramework.Services.Updates.GitHubUpdateCheckClient>();
+                    }
+#else
+                    services.AddHttpClient<SubZeroFramework.Services.Updates.IUpdateCheckClient, SubZeroFramework.Services.Updates.GitHubUpdateCheckClient>();
+#endif
+                    services.AddSingleton<SubZeroFramework.Services.Updates.IUpdateNotificationCoordinator>(provider =>
+                        new SubZeroFramework.Services.Updates.UpdateNotificationCoordinator(
+                            provider.GetRequiredService<SubZeroFramework.Services.Updates.IUpdateCheckClient>(),
+                            provider.GetRequiredService<SubZeroFramework.Services.Updates.IUpdateCheckStateStore>(),
+
+                            // Read through a delegate, not captured: the user can toggle this in Settings
+                            // mid-session and the next check must see the new answer.
+                            () => provider.GetRequiredService<ILocalClientSettingsStore>().AutomaticUpdateChecksEnabled,
+#if DEBUG
+                            // --fake-version makes the app claim to be older, so the REAL GitHub call is
+                            // still exercised. Falls through to the true version when the flag is absent.
+                            DebugUpdateOverrides.FakeCurrentVersion
+                                ?? SubZeroFramework.Services.Updates.AppVersion.Parse(
+                                    typeof(App).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion),
+#else
+                            SubZeroFramework.Services.Updates.AppVersion.Parse(
+                                typeof(App).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion),
+#endif
+                            () => DateTimeOffset.UtcNow,
+                            provider.GetRequiredService<ILogger<SubZeroFramework.Services.Updates.UpdateNotificationCoordinator>>()));
                     services.AddSingleton<ILocalFanProfileStore, LocalFanProfileStore>();
                     // Cross-platform launch-at-sign-in via the AutoLaunch library (HKCU Run key /
                     // freedesktop autostart / LaunchAgent behind one API).

--- a/SubZeroFramework/Controls/ScrollHint.cs
+++ b/SubZeroFramework/Controls/ScrollHint.cs
@@ -113,8 +113,8 @@ public static class ScrollHint
 
         void Update()
         {
-            upChevron.Opacity = HasMoreAbove(scrollViewer) ? 1d : 0d;
-            downChevron.Opacity = HasMoreBelow(scrollViewer) ? 1d : 0d;
+            FadeTo(upChevron, HasMoreAbove(scrollViewer) ? 1d : 0d);
+            FadeTo(downChevron, HasMoreBelow(scrollViewer) ? 1d : 0d);
         }
 
         scrollViewer.ViewChanged += (_, _) => Update();
@@ -293,7 +293,44 @@ public static class ScrollHint
             Margin = alignment == VerticalAlignment.Top ? new Thickness(0, 8, 0, 0) : new Thickness(0, 0, 0, 8),
             IsHitTestVisible = false,
             Opacity = 0d,
-            OpacityTransition = new ScalarTransition { Duration = TimeSpan.FromMilliseconds(140) },
         };
+    }
+
+    /// <summary>How long a chevron takes to fade in or out.</summary>
+    private static readonly TimeSpan FadeDuration = TimeSpan.FromMilliseconds(140);
+
+    /// <summary>
+    /// Fades <paramref name="chevron"/> to <paramref name="opacity"/>.
+    /// </summary>
+    /// <param name="chevron">The chevron to fade.</param>
+    /// <param name="opacity">The opacity to end at.</param>
+    /// <remarks>
+    /// An explicit storyboard rather than <c>UIElement.OpacityTransition</c>: that property is a WinUI
+    /// implicit animation Uno does not implement (Uno0001), so the fade it was supposed to provide simply
+    /// did not happen on the Skia head — the chevrons snapped. A storyboard behaves the same on both.
+    /// EnableDependentAnimation is required because Opacity here is not composition-animated.
+    /// </remarks>
+    private static void FadeTo(UIElement chevron, double opacity)
+    {
+        // Re-running the same fade on every scroll event would restart it continuously and leave the
+        // chevron flickering; ViewChanged fires for the whole length of a scroll.
+        if (Math.Abs(chevron.Opacity - opacity) < 0.01d)
+        {
+            return;
+        }
+
+        var animation = new DoubleAnimation
+        {
+            To = opacity,
+            Duration = new Duration(FadeDuration),
+            EnableDependentAnimation = true,
+        };
+
+        Storyboard.SetTarget(animation, chevron);
+        Storyboard.SetTargetProperty(animation, "Opacity");
+
+        var storyboard = new Storyboard();
+        storyboard.Children.Add(animation);
+        storyboard.Begin();
     }
 }

--- a/SubZeroFramework/Presentation/MainModel.cs
+++ b/SubZeroFramework/Presentation/MainModel.cs
@@ -3,6 +3,7 @@ using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.WinUI;
 
 using Microsoft.UI.Dispatching;
 
@@ -35,6 +36,12 @@ public partial class MainModel : ObservableObject, IDisposable
             .ObserveOn(context)
             .Subscribe(SystemStatusChanged)
             .DisposeWith(_subscriptions);
+
+        // The startup update check is deliberately NOT started here. Uno hands nested regions their own
+        // view-model instance, so the object whose constructor runs is not necessarily the one the page
+        // binds to: a check started here updated an instance nothing was watching — the icon never tinted,
+        // while clicking the rail item (which goes through the BOUND instance) worked every time.
+        // MainPage starts it, on the instance it actually binds.
     }
 
     /// <summary>Last observed health, so redirects fire on a transition rather than on every emission.</summary>
@@ -82,6 +89,7 @@ public partial class MainModel : ObservableObject, IDisposable
         if (healthChanged && SelectedItem is NavigationViewItemBase bs2 && bs2.Tag?.ToString() == "WarningIssues")
         {
             navigator.NavigateRouteAsync(this, "/Main/Dashboard");
+            _ = ShowUpdateNoticeAsync(force: true);
         }
 
         //For now enable all capabilities
@@ -134,4 +142,229 @@ public partial class MainModel : ObservableObject, IDisposable
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsWarningIssuesSelected))]
     public partial object? SelectedItem { get; set; }
+
+    private bool _startupUpdateCheckStarted;
+
+    /// <summary>
+    /// The shell has been navigated to — the first moment this view model is the one on screen.
+    /// </summary>
+    /// <remarks>
+    /// The NavigationView writes this back through a TwoWay binding once navigation settles, so it fires on
+    /// the instance the UI is actually bound to and only after the window is up. That is exactly what the
+    /// startup update check needs, and it needs no page-side lifecycle plumbing to get it.
+    /// </remarks>
+    partial void OnSelectedItemChanged(object? value)
+    {
+        if (_startupUpdateCheckStarted || value is null)
+        {
+            return;
+        }
+
+        _startupUpdateCheckStarted = true;
+        _ = ShowUpdateNoticeAsync(force: false);
+    }
+
+    /// <summary>
+    /// Handles the rail items that are ERRANDS rather than destinations.
+    /// </summary>
+    /// <remarks>
+    /// Check-for-updates is <c>SelectsOnInvoked="False"</c>, so it never becomes the selected item and
+    /// SelectionChanged never fires for it — which is the point. Handling it there instead meant navigating
+    /// to a region that does not exist and then going back, and that round trip is what blanked the content
+    /// area. ItemInvoked fires for selecting and non-selecting items alike.
+    /// </remarks>
+    /// <param name="sender">The rail.</param>
+    /// <param name="args">The invoked item.</param>
+    public void OnNavigationItemInvoked(NavigationView sender, NavigationViewItemInvokedEventArgs args)
+    {
+        if (string.Equals((args.InvokedItemContainer as NavigationViewItemBase)?.Tag?.ToString(), "CheckForUpdates", StringComparison.OrdinalIgnoreCase))
+        {
+            _ = ShowUpdateNoticeAsync(force: true);
+        }
+    }
+
+    /// <summary>
+    /// Opens the release page and closes the notice.
+    /// </summary>
+    /// <param name="sender">The notice.</param>
+    /// <param name="args">Unused.</param>
+    public void OnUpdateNoticeActionClick(TeachingTip sender, object args)
+    {
+        // Already validated as an https://github.com/TekuSP/SubZeroFramework/ URL by the client.
+        if (UpdateReleaseUrl is { Length: > 0 } url)
+        {
+            _ = Windows.System.Launcher.LaunchUriAsync(new Uri(url));
+        }
+
+        IsUpdateNoticeOpen = false;
+    }
+
+    /// <summary>
+    /// Runs a check and opens the notice when it has something to say.
+    /// </summary>
+    /// <param name="force">True when the user pressed the rail button; false for the check at startup.</param>
+    private async Task ShowUpdateNoticeAsync(bool force)
+    {
+        try
+        {
+            // The check marshals its own bindable writes, so it runs off the UI thread and only its RESULT
+            // comes back — enqueuing the whole call would put an HTTP request on the UI thread for no reason.
+            var hasNotice = await CheckForUpdatesAsync(force, CancellationToken.None).ConfigureAwait(false);
+
+            // Opening is a property set, not a call into the tip: the TwoWay binding lets XAML do the open
+            // when the visual tree is ready for it. Still a bindable write, so still marshalled.
+            await dispatcherQueue.EnqueueAsync(() => IsUpdateNoticeOpen = hasNotice);
+        }
+        catch (Exception exception)
+        {
+            // Fire-and-forget: an unobserved exception here would take the app down, and an update check is
+            // the last thing that should be able to do that.
+            System.Diagnostics.Debug.WriteLine($"The update check failed: {exception}");
+        }
+    }
+
+    // ----- Update notification -----
+
+    /// <summary>Tint for the rail's update icon: amber while a newer release exists, otherwise inherited.</summary>
+    /// <remarks>
+    /// Assigned at runtime, never in a field initializer — a Brush built off the UI thread fails silently
+    /// and takes the whole DataContext down with it. Null means "leave the icon alone", which is what the
+    /// rail's other items get.
+    /// </remarks>
+    [ObservableProperty]
+    public partial Microsoft.UI.Xaml.Media.Brush? UpdateIconBrush { get; private set; }
+
+    /// <summary>Title for the update notice.</summary>
+    [ObservableProperty]
+    public partial string UpdateNoticeTitle { get; private set; } = string.Empty;
+
+    /// <summary>Body for the update notice.</summary>
+    [ObservableProperty]
+    public partial string UpdateNoticeBody { get; private set; } = string.Empty;
+
+    /// <summary>Label for the notice's action button, or null when there is nowhere to go.</summary>
+    /// <remarks>
+    /// Null rather than empty: TeachingTip shows the action button whenever the property carries a value, so
+    /// only a null actually takes the button away on an up-to-date result.
+    /// </remarks>
+    [ObservableProperty]
+    public partial string? UpdateNoticeActionText { get; private set; }
+
+    /// <summary>
+    /// Whether the update notice is showing. Bound TwoWay, so XAML owns the actual open.
+    /// </summary>
+    /// <remarks>
+    /// Setting <c>TeachingTip.IsOpen</c> from code-behind meant fighting the visual tree's readiness: too
+    /// early and the tip anchors to an element with no layout and never appears. Through a binding the
+    /// framework opens it when it can, and TwoWay means a light-dismiss writes false back here rather than
+    /// leaving this stuck true and the tip un-reopenable.
+    /// </remarks>
+    [ObservableProperty]
+    public partial bool IsUpdateNoticeOpen { get; set; }
+
+    /// <summary>The release page to open, already validated as a github.com URL by the client.</summary>
+    public string? UpdateReleaseUrl { get; private set; }
+
+
+    /// <summary>
+    /// Runs an update check and prepares the notice copy.
+    /// </summary>
+    /// <param name="force">True when the user pressed the rail button; false for the check at startup.</param>
+    /// <returns>True when there is something to show.</returns>
+    /// <remarks>
+    /// A forced check ALWAYS produces something to show, including "you are up to date" — a button that
+    /// answers silently reads as broken. The startup check only speaks when there is news.
+    /// </remarks>
+    public async Task<bool> CheckForUpdatesAsync(bool force, CancellationToken cancellationToken)
+    {
+        var coordinator = ServiceProvider.GetService<Services.Updates.IUpdateNotificationCoordinator>();
+        if (coordinator is null)
+        {
+            return false;
+        }
+
+        // ConfigureAwait(false): the fetch has no business holding the UI thread, and nothing below touches
+        // a bindable property until the single marshalled block at the end.
+        var availability = await coordinator.EvaluateAsync(force, cancellationToken).ConfigureAwait(false);
+
+        // Decided off the UI thread on purpose — these are plain strings, so only the ASSIGNMENT needs
+        // marshalling, not the reasoning. An empty title means "nothing to say", which is what a silent
+        // startup check produces.
+        var (title, body) = DescribeUpdateNotice(availability, force);
+
+        await dispatcherQueue.EnqueueAsync(() =>
+        {
+            // Every bindable write lives in here. [ObservableProperty] raises PropertyChanged synchronously,
+            // so assigning off the UI thread pushes a binding update onto the wrong thread — and the brush
+            // below is worse still: AppThemeBrushes reaches into Application.Current.Resources, and a Brush
+            // touched off-thread fails silently, taking the assignment with it.
+            //
+            // The amber tint tracks the FACT, not the notice: it stays after the notice is dismissed, and a
+            // check that comes back clean is what clears it.
+            //
+            // A BRUSH OF ITS OWN, not AppThemeBrushes.Get. That helper hands back the very SolidColorBrush
+            // instance App.xaml owns and shares with every {StaticResource StatusWarningBrush} in the app,
+            // cached in a static dictionary for the process lifetime. Null means "no news", and the icon's
+            // binding turns that into the rail's ordinary colour.
+            UpdateIconBrush = availability.IsUpdateAvailable
+                ? new SolidColorBrush(Themes.AppThemeBrushes.StatusWarningColor)
+                : new SolidColorBrush(Themes.AppThemeBrushes.TextSecondaryColor);
+
+            UpdateReleaseUrl = availability.ReleaseUrl;
+            UpdateNoticeActionText = availability.IsUpdateAvailable ? "See what's new" : null;
+
+            if (title.Length > 0)
+            {
+                UpdateNoticeTitle = title;
+                UpdateNoticeBody = body;
+            }
+        });
+
+        return title.Length > 0;
+    }
+
+    /// <summary>
+    /// The notice copy for an outcome, or empty strings when there is nothing to say.
+    /// </summary>
+    /// <param name="availability">What the check found.</param>
+    /// <param name="force">True when the user asked; a startup check stays silent unless there is news.</param>
+    /// <returns>The title and body, both empty when the notice should not appear.</returns>
+    /// <remarks>
+    /// Static and string-only so it can run anywhere: keeping the wording out of the marshalled block leaves
+    /// that block doing nothing but assigning, which is the part that genuinely needs the UI thread.
+    /// </remarks>
+    private static (string Title, string Body) DescribeUpdateNotice(Models.UpdateAvailability availability, bool force)
+    {
+        if (availability.IsUpdateAvailable)
+        {
+            return (
+                $"SubZero {availability.LatestVersion} is available",
+                availability.CurrentVersion is { } running
+                    ? $"You're on {running}. See what changed on GitHub."
+                    : "See what changed on GitHub.");
+        }
+
+        // No news, and nobody asked.
+        if (!force)
+        {
+            return (string.Empty, string.Empty);
+        }
+
+        if (availability.Status == Models.UpdateCheckStatus.UpToDate)
+        {
+            return (
+                "You're up to date",
+                availability.CurrentVersion is { } currentVersion
+                    ? $"SubZero {currentVersion} is the newest release."
+                    : "No newer release was found.");
+        }
+
+        // Unknown: the feed could not be read, or this build carries no version to compare. Saying "up to
+        // date" here would assert something the app has no evidence for.
+        return (
+            "Couldn't check for updates",
+            availability.CurrentVersion is null
+                ? "This build doesn't report its version, so there's nothing to compare against."
+                : "GitHub could not be reached. Check your connection and try again.");
+    }
 }

--- a/SubZeroFramework/Presentation/MainPage.xaml
+++ b/SubZeroFramework/Presentation/MainPage.xaml
@@ -48,6 +48,7 @@
             IsBackEnabled="False"
             IsPaneToggleButtonVisible="False"
             IsSettingsVisible="False"
+            ItemInvoked="{x:Bind ViewModel.OnNavigationItemInvoked}"
             OpenPaneLength="250"
             PaneDisplayMode="LeftCompact"
             SelectedItem="{x:Bind ViewModel.SelectedItem, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -92,6 +93,28 @@
                     Icon="{len:FontIconStringExt Glyph={StaticResource WarningsMenuIcon}}"
                     IsEnabled="{x:Bind ViewModel.IsWarningIssuesEnabled, Mode=OneWay}"
                     Tag="WarningIssues" />
+                <!--
+                    A stock NavigationViewItem, not the Material one. That control exists for glyphs Segoe has
+                    no answer for — the fan, the expansion cards — and "update" is not one of them. It also
+                    carries a presenter that fans Foreground out to two MaterialIcons and swaps layouts off its
+                    own SizeChanged, and tinting through that rendered the entire row blank. A FontIcon takes a
+                    Foreground the ordinary way.
+                    
+                    SelectsOnInvoked="False" because this is an ERRAND, not a destination: it has no
+                    Region.Name, so letting it select sends navigation after a route that does not exist and
+                    empties the content area. ItemInvoked still fires for non-selecting items.
+                -->
+                <NavigationViewItem
+                    x:Name="CheckForUpdatesNavigationItem"
+                    Content="Check for updates"
+                    Foreground="{x:Bind ViewModel.UpdateIconBrush, Mode=OneWay, TargetNullValue={StaticResource BrandSecondaryBrush}}"
+                    SelectsOnInvoked="False"
+                    Tag="CheckForUpdates">
+                    <NavigationViewItem.Icon>
+                        <!--  TargetNullValue: no news leaves the icon the colour every other rail item uses.  -->
+                        <FontIcon Foreground="{x:Bind ViewModel.UpdateIconBrush, Mode=OneWay, TargetNullValue={StaticResource BrandSecondaryBrush}}" Glyph="{StaticResource UpdateMenuIcon}" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
                 <controls:NavigationMaterialViewItem
                     MaterialIconKindName="{StaticResource GithubMenuIcon}"
                     Tag="Github"
@@ -123,5 +146,21 @@
                 </Grid>
             </Grid>
         </NavigationView>
+
+        <!--
+            Anchored to the rail's update item, so the notice points at the control that raised it and at the
+            control that can raise it again. Light-dismiss: an update is news, never a decision to block on.
+        -->
+        <TeachingTip
+            x:Name="UpdateNoticeTip"
+            Title="{x:Bind ViewModel.UpdateNoticeTitle, Mode=OneWay}"
+            ActionButtonClick="{x:Bind ViewModel.OnUpdateNoticeActionClick}"
+            ActionButtonContent="{x:Bind ViewModel.UpdateNoticeActionText, Mode=OneWay}"
+            CloseButtonContent="Close"
+            IsLightDismissEnabled="True"
+            IsOpen="{x:Bind ViewModel.IsUpdateNoticeOpen, Mode=TwoWay}"
+            PreferredPlacement="RightBottom"
+            Subtitle="{x:Bind ViewModel.UpdateNoticeBody, Mode=OneWay}"
+            Target="{x:Bind CheckForUpdatesNavigationItem}" />
     </Grid>
 </Page>

--- a/SubZeroFramework/Presentation/MainPage.xaml.cs
+++ b/SubZeroFramework/Presentation/MainPage.xaml.cs
@@ -62,10 +62,19 @@ public sealed partial class MainPage : Page, INotifyPropertyChanged
 
     private void MainNavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
     {
-        if (string.Equals(args.SelectedItemContainer?.Tag?.ToString(), "Github", StringComparison.OrdinalIgnoreCase))
+        var tag = args.SelectedItemContainer?.Tag?.ToString();
+
+        if (string.Equals(tag, "Github", StringComparison.OrdinalIgnoreCase))
         {
             _ = Launcher.LaunchUriAsync(new Uri("https://github.com/TekuSP/SubZeroFramework"));
             _ = ViewModel!.navigator.GoBack(this);
+            return;
+        }
+
+        if (string.Equals(tag, "CheckForUpdates", StringComparison.OrdinalIgnoreCase))
+        {
+            _ = ViewModel!.navigator.GoBack(this);
+            return;
         }
     }
 }

--- a/SubZeroFramework/Presentation/MenuItems/Settings/Sections/SettingsStartupSectionModel.cs
+++ b/SubZeroFramework/Presentation/MenuItems/Settings/Sections/SettingsStartupSectionModel.cs
@@ -49,6 +49,7 @@ public partial class SettingsStartupSectionModel : ObservableObject, IUnsavedCha
     private bool? _savedAutorunEnabled;
     private bool _savedThermalAlertsEnabled;
     private bool _savedStatusNotificationsEnabled;
+    private bool _savedAutomaticUpdateChecksEnabled;
     private double _savedThresholdCelsius;
 
     public SettingsStartupSectionModel(
@@ -122,6 +123,10 @@ public partial class SettingsStartupSectionModel : ObservableObject, IUnsavedCha
     [ObservableProperty]
     public partial bool StatusNotificationsEnabled { get; set; }
 
+    /// <summary>Whether SubZero checks GitHub for a newer release. Silences only the AUTOMATIC check.</summary>
+    [ObservableProperty]
+    public partial bool AutomaticUpdateChecksEnabled { get; set; }
+
     [ObservableProperty]
     public partial bool AutorunIsOn { get; set; }
 
@@ -156,6 +161,8 @@ public partial class SettingsStartupSectionModel : ObservableObject, IUnsavedCha
     partial void OnThermalAlertsEnabledChanged(bool value) => OnStagedEditChanged();
 
     partial void OnStatusNotificationsEnabledChanged(bool value) => OnStagedEditChanged();
+
+    partial void OnAutomaticUpdateChecksEnabledChanged(bool value) => OnStagedEditChanged();
 
     partial void OnAutorunIsOnChanged(bool value) => OnStagedEditChanged();
 
@@ -196,6 +203,7 @@ public partial class SettingsStartupSectionModel : ObservableObject, IUnsavedCha
             || (_savedAutorunEnabled is bool savedAutorun && CanToggleAutorun && AutorunIsOn != savedAutorun)
             || ThermalAlertsEnabled != _savedThermalAlertsEnabled
             || StatusNotificationsEnabled != _savedStatusNotificationsEnabled
+            || AutomaticUpdateChecksEnabled != _savedAutomaticUpdateChecksEnabled
             || Math.Abs(_thresholdCelsius - _savedThresholdCelsius) >= ThresholdToleranceCelsius;
 
     private bool CanSaveOrCancel() => HasUnsavedChanges && !IsSaving;
@@ -230,6 +238,7 @@ public partial class SettingsStartupSectionModel : ObservableObject, IUnsavedCha
 
             _clientSettings.ThermalAlertsEnabled = ThermalAlertsEnabled;
             _clientSettings.StatusNotificationsEnabled = StatusNotificationsEnabled;
+            _clientSettings.AutomaticUpdateChecksEnabled = AutomaticUpdateChecksEnabled;
             _clientSettings.ThermalAlertThresholdCelsius = _thresholdCelsius;
 
             StartupStatusMessage = failures.Count == 0 ? "Settings saved." : string.Join(" ", failures);
@@ -264,6 +273,7 @@ public partial class SettingsStartupSectionModel : ObservableObject, IUnsavedCha
         StartWithSystemBoot = _savedStartWithSystemBoot = _startupRegistration.IsEnabled();
         ThermalAlertsEnabled = _savedThermalAlertsEnabled = _clientSettings.ThermalAlertsEnabled;
         StatusNotificationsEnabled = _savedStatusNotificationsEnabled = _clientSettings.StatusNotificationsEnabled;
+        AutomaticUpdateChecksEnabled = _savedAutomaticUpdateChecksEnabled = _clientSettings.AutomaticUpdateChecksEnabled;
         _thresholdCelsius = _savedThresholdCelsius = Math.Clamp(
             _clientSettings.ThermalAlertThresholdCelsius,
             ThermalAlertMonitor.MinimumThresholdCelsius,

--- a/SubZeroFramework/Presentation/MenuItems/Settings/Sections/SettingsStartupSectionView.xaml
+++ b/SubZeroFramework/Presentation/MenuItems/Settings/Sections/SettingsStartupSectionView.xaml
@@ -60,6 +60,14 @@
                     <Border Height="1" Background="{StaticResource SurfaceOutlineBrush}" />
 
                     <controls:ToggleRowView
+                        Title="Check for updates"
+                        Margin="0,7"
+                        IconKind="Update"
+                        IsOn="{x:Bind ViewModel.AutomaticUpdateChecksEnabled, Mode=TwoWay}"
+                        Subtitle="Tell me when a newer SubZero is released" />
+                    <Border Height="1" Background="{StaticResource SurfaceOutlineBrush}" />
+
+                    <controls:ToggleRowView
                         Title="Thermal alerts"
                         Margin="0,7"
                         IconKind="BellOutline"

--- a/SubZeroFramework/Services/DebugUpdateOverrides.cs
+++ b/SubZeroFramework/Services/DebugUpdateOverrides.cs
@@ -1,0 +1,78 @@
+#if DEBUG
+using SubZeroFramework.Models;
+using SubZeroFramework.Services.Updates;
+
+namespace SubZeroFramework.Services;
+
+/// <summary>
+/// Debug-build-only overrides for the update check, so its states can be reached without cutting a release.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The update notice is otherwise unreachable on a developer machine: it needs a published GitHub release
+/// that is strictly newer than the build in front of you, which is a chicken-and-egg problem exactly when
+/// you are trying to look at the UI. Editing <c>Directory.Build.props</c> works but rebuilds the world and
+/// is easy to forget to revert — and forgetting it ships a wrong version number.
+/// </para>
+/// <para>
+/// Two flags, because they test different halves:
+/// <list type="bullet">
+/// <item><c>--fake-version 0.0.1</c> — pretend the RUNNING app is that old. The real GitHub call still
+/// happens, so this exercises the whole path end to end. Needs network and a published release.</item>
+/// <item><c>--fake-latest 9.9.9</c> — pretend GitHub published that version, skipping the network entirely.
+/// Needs neither a release nor a connection, so it is the one that always works.</item>
+/// </list>
+/// Both may be combined. The whole type is compiled out of RELEASE: a stray argument must never be able to
+/// tell a user their install is out of date when it is not.
+/// </para>
+/// </remarks>
+internal static class DebugUpdateOverrides
+{
+    /// <summary>The release page a faked update points at — real, so the button goes somewhere sensible.</summary>
+    private const string ReleasePageUrl = "https://github.com/TekuSP/SubZeroFramework/releases/latest";
+
+    private static readonly Lazy<(Version? Current, Version? Latest)> Parsed = new(ParseCommandLine);
+
+    /// <summary>The version the app should claim to be, or null to use the real one.</summary>
+    public static Version? FakeCurrentVersion => Parsed.Value.Current;
+
+    /// <summary>The version GitHub should appear to have published, or null to actually ask it.</summary>
+    public static Version? FakeLatestVersion => Parsed.Value.Latest;
+
+    /// <summary>True when the network client should be replaced by <see cref="FakeClient"/>.</summary>
+    public static bool HasFakeLatest => FakeLatestVersion is not null;
+
+    private static (Version? Current, Version? Latest) ParseCommandLine()
+    {
+        var arguments = Environment.GetCommandLineArgs();
+        return (ReadVersionAfter(arguments, "--fake-version"), ReadVersionAfter(arguments, "--fake-latest"));
+    }
+
+    private static Version? ReadVersionAfter(string[] arguments, string flag)
+    {
+        for (var i = 0; i < arguments.Length - 1; i++)
+        {
+            if (string.Equals(arguments[i], flag, StringComparison.OrdinalIgnoreCase))
+            {
+                return AppVersion.Parse(arguments[i + 1]);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Answers with the faked release instead of asking GitHub.</summary>
+    internal sealed class FakeClient : IUpdateCheckClient
+    {
+        /// <inheritdoc />
+        public Task<UpdateCheckResult> FetchLatestAsync(string? etag, CancellationToken cancellationToken)
+            => Task.FromResult(new UpdateCheckResult(
+                new UpdateAvailability { LatestVersion = FakeLatestVersion, ReleaseUrl = ReleasePageUrl },
+
+                // A changing ETag on purpose: a cached one would let the 24 h interval skip the fetch and
+                // make the flag look broken on the second launch.
+                ETag: null,
+                NotModified: false));
+    }
+}
+#endif

--- a/SubZeroFramework/Services/LocalClientSettingsStore.cs
+++ b/SubZeroFramework/Services/LocalClientSettingsStore.cs
@@ -19,6 +19,16 @@ public interface ILocalClientSettingsStore
 
     /// <summary>Opt-in for service/fan-control status notifications (restart, install, curve applied, connection lost, …).</summary>
     bool StatusNotificationsEnabled { get; set; }
+
+    /// <summary>
+    /// Opt-out for the once-a-day GitHub release check and the notice it raises. On by default.
+    /// </summary>
+    /// <remarks>
+    /// Silences only the AUTOMATIC check. Pressing "Check for updates" is the user asking, and asking is
+    /// always honoured — this is the setting for someone deliberately staying on an older release, not a
+    /// master switch over their own button.
+    /// </remarks>
+    bool AutomaticUpdateChecksEnabled { get; set; }
 }
 
 public sealed class LocalClientSettingsStore : ILocalClientSettingsStore
@@ -53,6 +63,12 @@ public sealed class LocalClientSettingsStore : ILocalClientSettingsStore
     {
         get => _current.StatusNotificationsEnabled;
         set => Update(_current with { StatusNotificationsEnabled = value });
+    }
+
+    public bool AutomaticUpdateChecksEnabled
+    {
+        get => _current.AutomaticUpdateChecksEnabled;
+        set => Update(_current with { AutomaticUpdateChecksEnabled = value });
     }
 
     private void Update(StoredClientSettings settings)
@@ -100,6 +116,11 @@ public sealed class LocalClientSettingsStore : ILocalClientSettingsStore
         public double ThermalAlertThresholdCelsius { get; init; } = ThermalAlertMonitor.DefaultThresholdCelsius;
 
         public bool StatusNotificationsEnabled { get; init; }
+
+        // Defaults ON: the check is cheap, silent when it fails, and the notice is the only way a user
+        // learns a release exists. The initialiser is what makes the default hold for the settings files
+        // that already exist without this property.
+        public bool AutomaticUpdateChecksEnabled { get; init; } = true;
     }
 }
 

--- a/SubZeroFramework/Services/UpdateCheckStateStore.cs
+++ b/SubZeroFramework/Services/UpdateCheckStateStore.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using SubZeroFramework.Services.Updates;
+
+namespace SubZeroFramework.Services;
+
+/// <summary>
+/// Stores the update-check state next to the other client-only preferences.
+/// </summary>
+/// <remarks>
+/// Separate from <see cref="LocalClientSettingsStore"/> deliberately: that file holds what the USER chose,
+/// this one holds what the network last said. Mixing a cache into a settings file makes a corrupt cache look
+/// like lost settings.
+/// </remarks>
+public sealed class UpdateCheckStateStore : IUpdateCheckStateStore
+{
+    private readonly object _gate = new();
+
+    /// <summary>Creates the store and reads whatever a previous session left behind.</summary>
+    public UpdateCheckStateStore()
+    {
+        StateFilePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create),
+            "SubZeroFramework",
+            "update-check.json");
+        Current = ReadFromDisk();
+    }
+
+    /// <summary>Where the state lives.</summary>
+    public string StateFilePath { get; }
+
+    /// <inheritdoc />
+    public UpdateCheckState Current { get; private set; }
+
+    /// <inheritdoc />
+    public void Save(UpdateCheckState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        lock (_gate)
+        {
+            Current = state;
+
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(StateFilePath)!);
+                File.WriteAllText(StateFilePath, JsonSerializer.Serialize(state, UpdateCheckStateJsonContext.Default.UpdateCheckState));
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                // A cache that could not be written costs one extra request next launch. Nothing to report.
+            }
+        }
+    }
+
+    private UpdateCheckState ReadFromDisk()
+    {
+        try
+        {
+            if (File.Exists(StateFilePath))
+            {
+                return JsonSerializer.Deserialize(File.ReadAllText(StateFilePath), UpdateCheckStateJsonContext.Default.UpdateCheckState)
+                    ?? new UpdateCheckState();
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            // A corrupt cache must never block startup; an empty state simply re-checks.
+        }
+
+        return new UpdateCheckState();
+    }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(UpdateCheckState))]
+internal sealed partial class UpdateCheckStateJsonContext : JsonSerializerContext;

--- a/SubZeroFramework/SubZeroFramework.csproj
+++ b/SubZeroFramework/SubZeroFramework.csproj
@@ -18,6 +18,15 @@
              Directory.Build.props — invisible while both read 0.1.0, but every local build would keep
              stamping 0.1.0 after a bump. Let the SDK derive it. -->
         <ApplicationVersion>1</ApplicationVersion>
+        <!-- Uno.Sdk turns the assembly version attributes OFF (the package manifest owns the version in a
+             packaged app), which leaves an UNPACKAGED build reporting 0.0.0.0 and no informational version
+             at all. Settings > About then shows nothing real, and the update check has no version to
+             compare against GitHub, so it can only ever answer "couldn't check". Turned back on here: the
+             attributes are derived from the shared <Version> in Directory.Build.props, and CI overrides
+             both explicitly anyway. -->
+        <GenerateAssemblyVersionAttribute>true</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>true</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>true</GenerateAssemblyInformationalVersionAttribute>
         <!-- Package Publisher -->
         <ApplicationPublisher>Richard "TekuSP" Torhan</ApplicationPublisher>
         <!-- Package Description -->
@@ -83,6 +92,7 @@
         <PackageReference Include="IconifyBundle.SimpleIcons" GeneratePathProperty="true" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Uno.WinUI" />
         <PackageReference Include="Material.Icons" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="System.Drawing.Common" />
         <PackageReference Include="System.Reactive" />
         <PackageReference Include="Tmds.DBus" />


### PR DESCRIPTION
Checks GitHub Releases once a day and, while a newer version exists, says so in a TeachingTip anchored to a new "Check for updates" item in the rail. The rail icon stays amber for as long as the update is outstanding, so the notice can be dismissed without the fact being lost. Nothing downloads or installs — the action button opens the release page, and that is the whole of it.

Core owns the logic so it can be tested without a UI:

- AppVersion parses and compares the running and the published version, and reports Unknown rather than guessing when it cannot read one.
- GitHubUpdateCheckClient calls /releases/latest with the mandatory User-Agent, sends If-None-Match, and validates that the release URL really belongs to this repository before anything is allowed to open it.
- UpdateNotificationCoordinator holds the once-a-day rule and the up-to-date / available / unknown outcome. UpdateCheckStateStore persists the ETag and the last-check time so a restart does not re-spend the unauthenticated 60-per-hour budget.

The app head re-enables the assembly version attributes. Uno.Sdk turns them off because a packaged app's manifest owns the version, which left an unpackaged build reporting 0.0.0.0 and no informational version at all — Settings > About showed nothing real, and the check had no version to compare against. That is why it answered "you're up to date" while the repository was two releases ahead.

Settings gains an opt-out for the automatic check. It silences only the scheduled one: pressing the button is the user asking, and asking is always honoured.

The rail item is a stock NavigationViewItem with a FontIcon rather than the Material control its neighbours use. Tinting through that control's presenter — which fans Foreground into two MaterialIcons and switches layout off its own SizeChanged — rendered the entire row blank, icon and label together. It is also SelectsOnInvoked="False", because the item is an errand rather than a destination: letting it select sent navigation after a region that does not exist and emptied the content area.

Also replaces ScrollHint's OpacityTransition with an explicit storyboard. That property is a WinUI implicit animation Uno does not implement (Uno0001), so the fade never happened on the Skia head and the chevrons snapped instead.

Debug builds accept --fake-version and --fake-latest to exercise all three outcomes without waiting on a real release.